### PR TITLE
feat: add per-rule severity and --severity CLI override

### DIFF
--- a/.agents/skills/lintoko/SKILL.md
+++ b/.agents/skills/lintoko/SKILL.md
@@ -13,6 +13,7 @@ Repo: [github.com/caffeinelabs/lintoko](https://github.com/caffeinelabs/lintoko)
 
 ```toml
 name = "rule-name"
+severity = "warning"  # optional, defaults to "error"
 description = "Human-readable message. Can reference captures like @var."
 query = """
 (tree_sitter_query) @error
@@ -25,7 +26,8 @@ fix = "@captured_replacement"  # optional
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | yes | Kebab-case rule identifier (used in error output) |
-| `description` | yes | Error message shown to the user. Supports `@capture` templating — capture names are replaced with matched source text at report time |
+| `severity` | no | `"error"` (default) or `"warning"`. Warnings are reported but don't cause a non-zero exit code |
+| `description` | yes | Message shown to the user. Supports `@capture` templating — capture names are replaced with matched source text at report time |
 | `query` | yes | Tree-sitter query. Must contain at least one `@error` capture |
 | `fix` | no | Replacement template using `@capture` references. When `--fix` is passed, the `@error` range is replaced with this expanded string |
 
@@ -222,6 +224,7 @@ lintoko -r <rules-dir> [files/dirs/globs]   # lint files with a rule directory
 lintoko -r rules --fix                      # apply auto-fixes
 lintoko -r rules -f text                    # text output (vs pretty)
 lintoko -r my-rules -r more-rules src/      # multiple rule dirs
+lintoko -r rules -s warning src/            # treat all rules as warnings
 ```
 
 When no input files are specified, lintoko lints all `**/*.mo` files under the current directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- feat: add per-rule `severity` field (`"warning"` or `"error"`, defaults to `"error"`)
+- feat: add `--severity` CLI flag to override severity for all rules
 
 # 0.9.0
 - feat: allows matching/linting on nesting depth [#31](https://github.com/caffeinelabs/lintoko/pull/31)

--- a/example-rules/pun-fields.toml
+++ b/example-rules/pun-fields.toml
@@ -1,4 +1,5 @@
 name = "pun-fields"
+severity = "warning"
 description = "Use field punning to to avoid repetition: Replace `{ @field = @field }` with `{ @field }`"
 query = """
 ((exp_field

--- a/example-rules/unneeded-return.toml
+++ b/example-rules/unneeded-return.toml
@@ -1,4 +1,5 @@
 name = "unneeded-return"
+severity = "warning"
 description = "unneeded return statement. You can remove the `return`"
 # This is a bit simplistic in that it won't spot nested ifs or switches, but it covers the first 80%.
 # Doing this fully would require implementing recursive queries

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -178,6 +178,7 @@ mod test {
             description: "test".into(),
             query: query.into(),
             fix: None,
+            severity: Default::default(),
         };
         let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out).unwrap();
         assert_eq!(res.error_count, expected);
@@ -190,6 +191,7 @@ mod test {
             description: "test".into(),
             query: query.into(),
             fix: None,
+            severity: Default::default(),
         };
         let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out);
         assert!(res.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,17 +16,12 @@ pub enum OutputFormat {
     Text,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RuleSeverity {
     Warning,
+    #[default]
     Error,
-}
-
-impl Default for RuleSeverity {
-    fn default() -> Self {
-        RuleSeverity::Error
-    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -279,14 +274,13 @@ pub fn lint_file(
         )?
     }
 
-    let error_count = diagnostics
-        .iter()
-        .filter(|d| d.severity == RuleSeverity::Error)
-        .count();
-    let warning_count = diagnostics
-        .iter()
-        .filter(|d| d.severity == RuleSeverity::Warning)
-        .count();
+    let (error_count, warning_count) =
+        diagnostics
+            .iter()
+            .fold((0, 0), |(e, w), d| match d.severity {
+                RuleSeverity::Error => (e + 1, w),
+                RuleSeverity::Warning => (e, w + 1),
+            });
 
     Ok(LintResult {
         error_count,
@@ -343,6 +337,7 @@ mod test {
         let rules = load_rules_from_directory(Path::new("example-rules")).unwrap();
         let _err_count = lint_file(
             &Config {
+                fix: false,
                 format: OutputFormat::Text,
                 ..Config::default()
             },
@@ -413,5 +408,25 @@ mod test {
         .unwrap();
         assert_eq!(res.error_count, 1);
         assert_eq!(res.warning_count, 0);
+    }
+
+    #[test]
+    fn severity_override_demotes_errors_to_warnings() {
+        let mut out: Vec<u8> = vec![];
+        let rule = load_rule_from_file(Path::new("example-rules/no-let-else.toml")).unwrap();
+        assert_eq!(rule.severity, RuleSeverity::Error);
+        let res = lint_file(
+            &Config {
+                severity_override: Some(RuleSeverity::Warning),
+                ..Config::default()
+            },
+            "<input_path>",
+            "let ?x = foo() else { return }",
+            &[rule],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(res.error_count, 0);
+        assert_eq!(res.warning_count, 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,24 @@ pub enum OutputFormat {
     Text,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleSeverity {
+    Warning,
+    Error,
+}
+
+impl Default for RuleSeverity {
+    fn default() -> Self {
+        RuleSeverity::Error
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Config {
     pub format: OutputFormat,
     pub fix: bool,
+    pub severity_override: Option<RuleSeverity>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -28,6 +42,8 @@ pub struct Rule {
     description: String,
     query: String,
     fix: Option<String>,
+    #[serde(default)]
+    severity: RuleSeverity,
 }
 
 #[derive(Debug, Clone)]
@@ -36,6 +52,7 @@ struct RawDiagnostic {
     description: String,
     range: Range,
     fix: Option<String>,
+    severity: RuleSeverity,
 }
 
 pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
@@ -136,6 +153,7 @@ fn apply_rule(rule: &Rule, tree: Node, input: &str) -> Result<Vec<RawDiagnostic>
             description,
             range,
             fix,
+            severity: rule.severity,
         };
         diagnostics.push(diagnostic);
     }
@@ -144,8 +162,12 @@ fn apply_rule(rule: &Rule, tree: Node, input: &str) -> Result<Vec<RawDiagnostic>
 
 fn print_pretty_diagnostic(path: &str, source_code: &str, diagnostic: &RawDiagnostic) -> String {
     let source_code = NamedSource::new(path, source_code.to_string());
+    let (miette_severity, label) = match diagnostic.severity {
+        RuleSeverity::Warning => (Severity::Warning, "[WARNING]"),
+        RuleSeverity::Error => (Severity::Error, "[ERROR]"),
+    };
     let report = miette!(
-        severity = Severity::Error,
+        severity = miette_severity,
         labels = vec![LabeledSpan::new_primary_with_span(
             Some(diagnostic.description.clone()),
             (
@@ -153,7 +175,7 @@ fn print_pretty_diagnostic(path: &str, source_code: &str, diagnostic: &RawDiagno
                 diagnostic.range.end_byte - diagnostic.range.start_byte
             )
         )],
-        "[ERROR]: {}",
+        "{label}: {}",
         diagnostic.rule
     )
     .with_source_code(source_code);
@@ -176,9 +198,13 @@ fn print_text_diagnostic(path: &str, source_code: &str, diagnostic: &RawDiagnost
         snippet += &format!("{padding}{l} {line}\n");
     }
 
+    let severity_label = match diagnostic.severity {
+        RuleSeverity::Warning => "Warning",
+        RuleSeverity::Error => "Error",
+    };
     let start = format!("{start_line}:{}", diagnostic.range.start_point.column);
     format!(
-        "{path}:{start} Error: {description}\nFound in:\n{snippet}",
+        "{path}:{start} {severity_label}: {description}\nFound in:\n{snippet}",
         description = diagnostic.description
     )
 }
@@ -186,6 +212,7 @@ fn print_text_diagnostic(path: &str, source_code: &str, diagnostic: &RawDiagnost
 #[derive(Debug)]
 pub struct LintResult {
     pub error_count: usize,
+    pub warning_count: usize,
     pub fixed_file: Option<String>,
 }
 
@@ -204,6 +231,11 @@ pub fn lint_file(
     let mut diagnostics = Vec::new();
     for rule in rules {
         diagnostics.extend(apply_rule(rule, tree.root_node(), input)?);
+    }
+    if let Some(severity) = config.severity_override {
+        for d in &mut diagnostics {
+            d.severity = severity;
+        }
     }
     diagnostics.sort_by_key(|d| d.range.start_byte);
     for diagnostic in &diagnostics {
@@ -247,8 +279,18 @@ pub fn lint_file(
         )?
     }
 
+    let error_count = diagnostics
+        .iter()
+        .filter(|d| d.severity == RuleSeverity::Error)
+        .count();
+    let warning_count = diagnostics
+        .iter()
+        .filter(|d| d.severity == RuleSeverity::Warning)
+        .count();
+
     Ok(LintResult {
-        error_count: diagnostics.len(),
+        error_count,
+        warning_count,
         fixed_file,
     })
 }
@@ -269,6 +311,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.error_count, 0);
+        assert_eq!(res.warning_count, 0);
         assert_eq!(str::from_utf8(&out).unwrap(), "");
     }
 
@@ -300,8 +343,8 @@ mod test {
         let rules = load_rules_from_directory(Path::new("example-rules")).unwrap();
         let _err_count = lint_file(
             &Config {
-                fix: false,
                 format: OutputFormat::Text,
+                ..Config::default()
             },
             "<input_path>",
             include_str!("../test-data.mo"),
@@ -324,6 +367,7 @@ mod test {
             &Config {
                 fix: true,
                 format: OutputFormat::Text,
+                ..Config::default()
             },
             "<input_path>",
             "{ x = x }",
@@ -332,5 +376,42 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.fixed_file.unwrap(), "{ x }".to_string())
+    }
+
+    #[test]
+    fn warning_severity_does_not_count_as_error() {
+        let mut out: Vec<u8> = vec![];
+        let rule = load_rule_from_file(Path::new("example-rules/pun-fields.toml")).unwrap();
+        assert_eq!(rule.severity, RuleSeverity::Warning);
+        let res = lint_file(
+            &Config::default(),
+            "<input_path>",
+            "{ x = x }",
+            &[rule],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(res.error_count, 0);
+        assert_eq!(res.warning_count, 1);
+    }
+
+    #[test]
+    fn severity_override_promotes_warnings_to_errors() {
+        let mut out: Vec<u8> = vec![];
+        let rule = load_rule_from_file(Path::new("example-rules/pun-fields.toml")).unwrap();
+        assert_eq!(rule.severity, RuleSeverity::Warning);
+        let res = lint_file(
+            &Config {
+                severity_override: Some(RuleSeverity::Error),
+                ..Config::default()
+            },
+            "<input_path>",
+            "{ x = x }",
+            &[rule],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(res.error_count, 1);
+        assert_eq!(res.warning_count, 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,16 @@ struct Args {
     /// When passing a file path, will _only_ use the rule in that file
     #[arg(short, long, value_name = "DIRECTORY")]
     rules: Vec<PathBuf>,
+
+    /// Override severity for all rules
+    #[arg(short, long, value_enum)]
+    severity: Option<CliSeverity>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum CliSeverity {
+    Warning,
+    Error,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -89,6 +99,10 @@ fn main() -> Result<()> {
             OutputFormat::Pretty => lintoko::OutputFormat::Pretty,
             OutputFormat::Text => lintoko::OutputFormat::Text,
         },
+        severity_override: args.severity.map(|s| match s {
+            CliSeverity::Warning => lintoko::RuleSeverity::Warning,
+            CliSeverity::Error => lintoko::RuleSeverity::Error,
+        }),
     };
 
     let inputs = if args.inputs.is_empty() {
@@ -114,6 +128,7 @@ fn main() -> Result<()> {
     }
 
     let mut error_count = 0;
+    let mut warning_count = 0;
     for input in all_files {
         debug!("Linting file: {}", input.display());
 
@@ -128,6 +143,7 @@ fn main() -> Result<()> {
             std::io::stderr(),
         )?;
         error_count += res.error_count;
+        warning_count += res.warning_count;
         if let Some(fixed_file) = res.fixed_file {
             debug!("Writing fixed file: {}", input.display());
             fs::write(&input, fixed_file)?
@@ -135,7 +151,14 @@ fn main() -> Result<()> {
     }
 
     if error_count > 0 {
-        bail!("Found {error_count} errors")
+        if warning_count > 0 {
+            bail!("Found {error_count} errors and {warning_count} warnings")
+        } else {
+            bail!("Found {error_count} errors")
+        }
+    } else if warning_count > 0 {
+        eprintln!("Found {warning_count} warnings");
+        Ok(())
     } else {
         Ok(())
     }

--- a/src/snapshots/lintoko__test__it_lints_example_rules.snap
+++ b/src/snapshots/lintoko__test__it_lints_example_rules.snap
@@ -1,6 +1,5 @@
 ---
 source: src/lib.rs
-assertion_line: 290
 expression: lint_output
 ---
   × [ERROR]: no-result
@@ -146,7 +145,7 @@ expression: lint_output
  36 │   x := "1" # x;
     ╰────
 
-  × [ERROR]: pun-fields
+  ⚠ [WARNING]: pun-fields
     ╭─[<input_path>:38:13]
  37 │ 
  38 │   let _ = { field = field };
@@ -204,7 +203,7 @@ expression: lint_output
  61 │     null
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:73:5]
  72 │   func unneededReturn() {
  73 │     return 10
@@ -213,7 +212,7 @@ expression: lint_output
  74 │   };
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:75:27]
  74 │   };
  75 │   func unneededReturn() = return 10;
@@ -222,7 +221,7 @@ expression: lint_output
  76 │ 
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:79:7]
  78 │     if (true) {
  79 │       return 4;
@@ -231,7 +230,7 @@ expression: lint_output
  80 │     } else {
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:86:15]
  85 │   func unneededReturn() {
  86 │     if (true) return 4
@@ -240,7 +239,7 @@ expression: lint_output
  87 │     else {
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:95:14]
  94 │     switch (true) {
  95 │       case 1 return 40;
@@ -249,7 +248,7 @@ expression: lint_output
  96 │       case 2 { return 40; };
     ╰────
 
-  × [ERROR]: unneeded-return
+  ⚠ [WARNING]: unneeded-return
     ╭─[<input_path>:96:16]
  95 │       case 1 return 40;
  96 │       case 2 { return 40; };

--- a/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
+++ b/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
@@ -1,6 +1,5 @@
 ---
 source: src/lib.rs
-assertion_line: 312
 expression: lint_output
 ---
 <input_path>:1:0 Error: Do not use the Result pattern. Use Runtime.trap() instead.
@@ -67,7 +66,7 @@ Found in:
 Found in:
 35   x := x # "1";
 
-<input_path>:38:12 Error: Use field punning to to avoid repetition: Replace `{ field = field }` with `{ field }`
+<input_path>:38:12 Warning: Use field punning to to avoid repetition: Replace `{ field = field }` with `{ field }`
 Found in:
 38   let _ = { field = field };
 
@@ -97,27 +96,27 @@ Found in:
 Found in:
 60   public func mapReturningFunction() : async Map.Map<Text, Nat> {
 
-<input_path>:73:4 Error: unneeded return statement. You can remove the `return`
+<input_path>:73:4 Warning: unneeded return statement. You can remove the `return`
 Found in:
 73     return 10
 
-<input_path>:75:26 Error: unneeded return statement. You can remove the `return`
+<input_path>:75:26 Warning: unneeded return statement. You can remove the `return`
 Found in:
 75   func unneededReturn() = return 10;
 
-<input_path>:79:6 Error: unneeded return statement. You can remove the `return`
+<input_path>:79:6 Warning: unneeded return statement. You can remove the `return`
 Found in:
 79       return 4;
 
-<input_path>:86:14 Error: unneeded return statement. You can remove the `return`
+<input_path>:86:14 Warning: unneeded return statement. You can remove the `return`
 Found in:
 86     if (true) return 4
 
-<input_path>:95:13 Error: unneeded return statement. You can remove the `return`
+<input_path>:95:13 Warning: unneeded return statement. You can remove the `return`
 Found in:
 95       case 1 return 40;
 
-<input_path>:96:15 Error: unneeded return statement. You can remove the `return`
+<input_path>:96:15 Warning: unneeded return statement. You can remove the `return`
 Found in:
 96       case 2 { return 40; };
 


### PR DESCRIPTION
Rules can now specify `severity = "warning"` in their TOML file (defaults to `"error"`). Warnings are reported but don't cause a non-zero exit code.

A `--severity` / `-s` CLI flag overrides all rules globally:
- `--severity warning` — nothing fails the run
- `--severity error` — all findings fail the run

Example rules `pun-fields` and `unneeded-return` now default to warning.