### PR TITLE
feat: per-rule includes/excludes glob fields for path scoping

### DIFF
--- a/.agents/skills/lintoko/SKILL.md
+++ b/.agents/skills/lintoko/SKILL.md
@@ -19,6 +19,8 @@ query = """
 (tree_sitter_query) @error
 """
 fix = "@captured_replacement"  # optional
+includes = ["backend/types/**"]      # optional
+excludes = ["**/*.test.mo"]          # optional
 ```
 
 ### Fields
@@ -30,6 +32,18 @@ fix = "@captured_replacement"  # optional
 | `description` | yes | Message shown to the user. Supports `@capture` templating — capture names are replaced with matched source text at report time |
 | `query` | yes | Tree-sitter query. Must contain at least one `@error` capture |
 | `fix` | no | Replacement template using `@capture` references. When `--fix` is passed, the `@error` range is replaced with this expanded string |
+| `includes` | no | List of globs; rule only runs on paths matching at least one. Empty/absent = match all |
+| `excludes` | no | List of globs; rule is skipped on any matching path |
+
+### Path filtering (`includes` / `excludes`)
+
+Globs match the path string lintoko was handed (typically project-relative because `mops lint` runs from the project root). Patterns are anchored to the full path; use `**` to match any number of segments.
+
+- Scope a rule to a directory: `includes = ["backend/types/**"]`
+- Allowlist permitted locations: `excludes = ["backend/types/**", "backend/lib/**", "backend/main.mo"]` paired with `query = "(source_file) @error"` flags any `.mo` file outside the listed paths.
+- Both fields together: file must match at least one `include` AND no `exclude`.
+
+Patterns are validated at load time, so typos surface before linting starts.
 
 ### TOML string quoting
 
@@ -103,34 +117,8 @@ Match any of several node structures with `[...]`. A capture after `]` captures 
 | `#match?` regex | `(#match? @import "pure")` |
 | `#not-match?` | `(#not-match? @ident "^[a-z_][a-zA-Z0-9]*$")` |
 | `#any-of?` set | `(#any-of? @type "List" "Set" "Map")` |
-| `#match-file?` regex | `(#match-file? "^backend/types/")` |
-| `#not-match-file?` regex | `(#not-match-file? "^backend/main\.mo$")` |
 
-Predicates go inside the outermost `()` of the pattern. Multiple `#not-eq?` predicates create an **allowlist** — everything is flagged except listed values.
-
-### Path predicates (`#match-file?` / `#not-match-file?`)
-
-Match the **file path currently being linted** against a regex. Take no capture argument — only the path matters. Two use cases:
-
-1. **Scope a rule to a directory**: `(#match-file? "^backend/lib/")` makes the rule fire only for files under `backend/lib/`.
-2. **Enforce directory structure**: match on `source_file` with stacked `#not-match-file?` predicates to allowlist permitted paths. See `example-rules/allowed-directories.toml`.
-
-**Path contract** — the predicate receives the raw path string lintoko was handed, same as shown in diagnostics. Typically project-relative because `mops lint` runs from the project root.
-
-**Authoring:**
-
-- Use project-relative, forward-slash paths with `^` anchors (`^backend/types/`).
-- Unanchored `backend/types/` matches the substring anywhere — usually wrong for layout rules.
-- Path-dependent rules assume CWD = project root.
-
-**Multiple predicates AND** — readable as one predicate per allowed path:
-
-```
-((source_file) @error
- (#not-match-file? "^backend/types/")
- (#not-match-file? "^backend/lib/")
- (#not-match-file? "^backend/main\.mo$"))
-```
+Predicates go inside the outermost `()` of the pattern. Multiple `#not-eq?` predicates create an **allowlist** — everything is flagged except listed values. For path-based scoping use the `includes`/`excludes` rule fields instead of predicates.
 
 ### Multiple patterns
 

--- a/.agents/skills/lintoko/SKILL.md
+++ b/.agents/skills/lintoko/SKILL.md
@@ -103,8 +103,42 @@ Match any of several node structures with `[...]`. A capture after `]` captures 
 | `#match?` regex | `(#match? @import "pure")` |
 | `#not-match?` | `(#not-match? @ident "^[a-z_][a-zA-Z0-9]*$")` |
 | `#any-of?` set | `(#any-of? @type "List" "Set" "Map")` |
+| `#match-file?` regex | `(#match-file? "^backend/types/")` |
+| `#not-match-file?` regex | `(#not-match-file? "^backend/main\.mo$")` |
 
 Predicates go inside the outermost `()` of the pattern. Multiple `#not-eq?` predicates create an **allowlist** — everything is flagged except listed values.
+
+### Path predicates (`#match-file?` / `#not-match-file?`)
+
+Lintoko-specific custom predicates that match the **path of the file currently being linted** against a regex. Unlike `#match?`, these take no capture argument — they only depend on the filepath, not on any matched node.
+
+Two use cases:
+
+1. **Scope a rule to a directory**: `(#match-file? "^backend/lib/")` makes the rule only fire for files under `backend/lib/`.
+2. **Enforce directory structure**: match on `source_file` and use `#not-match-file?` to allowlist permitted paths; anything outside fires an error. See `example-rules/allowed-directories.toml`.
+
+**Path contract** — the predicate receives the exact path string lintoko was handed, which is the same path shown in diagnostics. In practice, this is **project-relative** because:
+
+- `mops lint` invokes lintoko with CWD at the project root.
+- CLI globs expand to paths in the same form as the input pattern.
+
+**Authoring conventions:**
+
+- Write regexes against **project-relative, forward-slash paths** (e.g. `^backend/types/`).
+- Anchored `^backend/` means "starting at project root"; unanchored `backend/types/` matches the substring anywhere in the path — usually not what you want.
+- Path-dependent rules assume lintoko is invoked from the project root. Running from elsewhere (or with absolute paths) is unsupported for those rules.
+- Windows backslash paths are not normalized.
+
+**ANDing multiple predicates** — predicates on the same pattern are conjoined; the match only fires when all pass. This makes allow-lists readable as one predicate per allowed path:
+
+```
+((source_file) @error
+ (#not-match-file? "^backend/types/")
+ (#not-match-file? "^backend/lib/")
+ (#not-match-file? "^backend/main\.mo$"))
+```
+
+**Quoting** — regex escapes like `\.` are clearer in `'''` triple-single-quoted TOML strings than in `"""` (which requires `\\.`).
 
 ### Multiple patterns
 

--- a/.agents/skills/lintoko/SKILL.md
+++ b/.agents/skills/lintoko/SKILL.md
@@ -40,7 +40,7 @@ excludes = ["**/*.test.mo"]          # optional
 Globs match the path string lintoko was handed (typically project-relative because `mops lint` runs from the project root). Patterns are anchored to the full path; use `**` to match any number of segments.
 
 - Scope a rule to a directory: `includes = ["backend/types/**"]`
-- Allowlist permitted locations: `excludes = ["backend/types/**", "backend/lib/**", "backend/main.mo"]` paired with `query = "(source_file) @error"` flags any `.mo` file outside the listed paths.
+- Enforce a directory layout: pair `query = "(source_file) @error"` with `excludes = [...permitted paths...]` so the rule fires on every file *outside* the allowlist.
 - Both fields together: file must match at least one `include` AND no `exclude`.
 
 Patterns are validated at load time, so typos surface before linting starts.

--- a/.agents/skills/lintoko/SKILL.md
+++ b/.agents/skills/lintoko/SKILL.md
@@ -110,26 +110,20 @@ Predicates go inside the outermost `()` of the pattern. Multiple `#not-eq?` pred
 
 ### Path predicates (`#match-file?` / `#not-match-file?`)
 
-Lintoko-specific custom predicates that match the **path of the file currently being linted** against a regex. Unlike `#match?`, these take no capture argument — they only depend on the filepath, not on any matched node.
+Match the **file path currently being linted** against a regex. Take no capture argument — only the path matters. Two use cases:
 
-Two use cases:
+1. **Scope a rule to a directory**: `(#match-file? "^backend/lib/")` makes the rule fire only for files under `backend/lib/`.
+2. **Enforce directory structure**: match on `source_file` with stacked `#not-match-file?` predicates to allowlist permitted paths. See `example-rules/allowed-directories.toml`.
 
-1. **Scope a rule to a directory**: `(#match-file? "^backend/lib/")` makes the rule only fire for files under `backend/lib/`.
-2. **Enforce directory structure**: match on `source_file` and use `#not-match-file?` to allowlist permitted paths; anything outside fires an error. See `example-rules/allowed-directories.toml`.
+**Path contract** — the predicate receives the raw path string lintoko was handed, same as shown in diagnostics. Typically project-relative because `mops lint` runs from the project root.
 
-**Path contract** — the predicate receives the exact path string lintoko was handed, which is the same path shown in diagnostics. In practice, this is **project-relative** because:
+**Authoring:**
 
-- `mops lint` invokes lintoko with CWD at the project root.
-- CLI globs expand to paths in the same form as the input pattern.
+- Use project-relative, forward-slash paths with `^` anchors (`^backend/types/`).
+- Unanchored `backend/types/` matches the substring anywhere — usually wrong for layout rules.
+- Path-dependent rules assume CWD = project root.
 
-**Authoring conventions:**
-
-- Write regexes against **project-relative, forward-slash paths** (e.g. `^backend/types/`).
-- Anchored `^backend/` means "starting at project root"; unanchored `backend/types/` matches the substring anywhere in the path — usually not what you want.
-- Path-dependent rules assume lintoko is invoked from the project root. Running from elsewhere (or with absolute paths) is unsupported for those rules.
-- Windows backslash paths are not normalized.
-
-**ANDing multiple predicates** — predicates on the same pattern are conjoined; the match only fires when all pass. This makes allow-lists readable as one predicate per allowed path:
+**Multiple predicates AND** — readable as one predicate per allowed path:
 
 ```
 ((source_file) @error
@@ -137,8 +131,6 @@ Two use cases:
  (#not-match-file? "^backend/lib/")
  (#not-match-file? "^backend/main\.mo$"))
 ```
-
-**Quoting** — regex escapes like `\.` are clearer in `'''` triple-single-quoted TOML strings than in `"""` (which requires `\\.`).
 
 ### Multiple patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
 - feat: add per-rule `severity` field (`"warning"` or `"error"`, defaults to `"error"`)
 - feat: add `--severity` CLI flag to override severity for all rules
-- feat: add `#match-file?` / `#not-match-file?` custom predicates for path-dependent rules
-- feat: add `allowed-directories` and `types-only` example rules demonstrating path predicates
+- feat: add per-rule `includes` / `excludes` glob fields for scoping rules to file paths
+- feat: add `allowed-directories` and `types-only` example rules demonstrating path scoping
 
 # 0.9.0
 - feat: allows matching/linting on nesting depth [#31](https://github.com/caffeinelabs/lintoko/pull/31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Unreleased
 - feat: add per-rule `severity` field (`"warning"` or `"error"`, defaults to `"error"`)
 - feat: add `--severity` CLI flag to override severity for all rules
-- feat: add per-rule `includes` / `excludes` glob fields for scoping rules to file paths
-- feat: add `allowed-directories` and `types-only` example rules demonstrating path scoping
+- feat: add per-rule `includes` / `excludes` glob fields for scoping rules to file paths (with `allowed-directories` and `types-only` example rules)
 
 # 0.9.0
 - feat: allows matching/linting on nesting depth [#31](https://github.com/caffeinelabs/lintoko/pull/31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 - feat: add per-rule `severity` field (`"warning"` or `"error"`, defaults to `"error"`)
 - feat: add `--severity` CLI flag to override severity for all rules
+- feat: add `#match-file?` / `#not-match-file?` custom predicates for path-dependent rules
+- feat: add `allowed-directories` and `types-only` example rules demonstrating path predicates
 
 # 0.9.0
 - feat: allows matching/linting on nesting depth [#31](https://github.com/caffeinelabs/lintoko/pull/31)

--- a/example-rules/allowed-directories.toml
+++ b/example-rules/allowed-directories.toml
@@ -1,0 +1,11 @@
+name = "allowed-directories"
+description = "Motoko files must live in an allowed backend directory"
+query = '''
+((source_file) @error
+ (#not-match-file? "^backend/types/")
+ (#not-match-file? "^backend/lib/")
+ (#not-match-file? "^backend/mixins/")
+ (#not-match-file? "^backend/migrations/")
+ (#not-match-file? "^backend/next-migration/")
+ (#not-match-file? "^backend/main\.mo$"))
+'''

--- a/example-rules/allowed-directories.toml
+++ b/example-rules/allowed-directories.toml
@@ -1,11 +1,11 @@
 name = "allowed-directories"
 description = "Motoko files must live in an allowed backend directory"
-query = '''
-((source_file) @error
- (#not-match-file? "^backend/types/")
- (#not-match-file? "^backend/lib/")
- (#not-match-file? "^backend/mixins/")
- (#not-match-file? "^backend/migrations/")
- (#not-match-file? "^backend/next-migration/")
- (#not-match-file? "^backend/main\.mo$"))
-'''
+excludes = [
+    "backend/types/**",
+    "backend/lib/**",
+    "backend/mixins/**",
+    "backend/migrations/**",
+    "backend/next-migration/**",
+    "backend/main.mo",
+]
+query = "(source_file) @error"

--- a/example-rules/types-only.toml
+++ b/example-rules/types-only.toml
@@ -1,6 +1,7 @@
 name = "types-only"
 description = "Files under backend/types/ must contain only type declarations. No functions, classes, or variable bindings."
+includes = ["backend/types/**"]
 query = '''
-((dec_field (_) @error) (#match-file? "^backend/types/"))
+(dec_field (_) @error)
 (dec_field (typ_dec) @filter)
 '''

--- a/example-rules/types-only.toml
+++ b/example-rules/types-only.toml
@@ -1,0 +1,6 @@
+name = "types-only"
+description = "Files under backend/types/ must contain only type declarations. No functions, classes, or variable bindings."
+query = '''
+((dec_field (_) @error) (#match-file? "^backend/types/"))
+(dec_field (typ_dec) @filter)
+'''

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use regex::Regex;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, QueryCapture, QueryPredicate, QueryPredicateArg};
@@ -90,10 +91,29 @@ fn eval_depth_predicate<'q>(
     Ok(depth_fn(node, types) >= threshold)
 }
 
+fn eval_file_predicate<'q>(
+    pred: &'q QueryPredicate,
+    file_path: &str,
+    regex_cache: &mut HashMap<&'q str, Regex>,
+) -> Result<bool> {
+    let pattern = resolve_string_arg(&pred.args, 0)?;
+    let regex = match regex_cache.entry(pattern) {
+        Entry::Occupied(e) => e.into_mut(),
+        Entry::Vacant(e) => {
+            let compiled = Regex::new(pattern)
+                .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
+            e.insert(compiled)
+        }
+    };
+    Ok(regex.is_match(file_path))
+}
+
 fn evaluate_predicates<'q>(
     predicates: &'q [QueryPredicate],
     captures: &[QueryCapture<'_>],
+    file_path: &str,
     types_cache: &mut HashMap<&'q str, HashSet<&'q str>>,
+    regex_cache: &mut HashMap<&'q str, Regex>,
 ) -> Result<bool> {
     for pred in predicates {
         let op = pred.operator.as_ref();
@@ -107,6 +127,10 @@ fn evaluate_predicates<'q>(
                 eval_depth_predicate(pred, captures, types_cache, depth_fn)
                     .with_context(|| format!("in #{op}"))?
             }
+            "match-file?" => eval_file_predicate(pred, file_path, regex_cache)
+                .with_context(|| format!("in #{op}"))?,
+            "not-match-file?" => !eval_file_predicate(pred, file_path, regex_cache)
+                .with_context(|| format!("in #{op}"))?,
             unknown => bail!("Unknown custom predicate: #{unknown}"),
         };
         if !pass {
@@ -122,19 +146,23 @@ fn is_trailing(m: &tree_sitter::QueryMatch, idx: u32) -> bool {
         .any(|n| n.next_named_sibling().is_some())
 }
 
-pub struct MatchEvaluator<'q> {
+pub struct MatchEvaluator<'q, 'p> {
     query: &'q tree_sitter::Query,
     trailing_idx: Option<u32>,
     filter_idx: Option<u32>,
+    file_path: &'p str,
     types_cache: HashMap<&'q str, HashSet<&'q str>>,
+    regex_cache: HashMap<&'q str, Regex>,
 }
 
-impl<'q> MatchEvaluator<'q> {
-    pub fn new(query: &'q tree_sitter::Query) -> Self {
+impl<'q, 'p> MatchEvaluator<'q, 'p> {
+    pub fn new(query: &'q tree_sitter::Query, file_path: &'p str) -> Self {
         Self {
             trailing_idx: query.capture_index_for_name("trailing"),
             filter_idx: query.capture_index_for_name("filter"),
+            file_path,
             types_cache: HashMap::new(),
+            regex_cache: HashMap::new(),
             query,
         }
     }
@@ -147,7 +175,13 @@ impl<'q> MatchEvaluator<'q> {
         }
         let predicates = self.query.general_predicates(m.pattern_index);
         if !predicates.is_empty()
-            && !evaluate_predicates(predicates, m.captures, &mut self.types_cache)?
+            && !evaluate_predicates(
+                predicates,
+                m.captures,
+                self.file_path,
+                &mut self.types_cache,
+                &mut self.regex_cache,
+            )?
         {
             return Ok(true);
         }
@@ -169,9 +203,14 @@ impl<'q> MatchEvaluator<'q> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Config, Rule, lint_file};
+    use crate::{Config, Rule, lint_file, load_rule_from_file};
+    use std::path::Path;
 
     fn assert_lint_count(query: &str, input: &str, expected: usize) {
+        assert_lint_count_at_path(query, input, "<test>", expected);
+    }
+
+    fn assert_lint_count_at_path(query: &str, input: &str, path: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
         let rule = Rule {
             name: "test".into(),
@@ -180,7 +219,7 @@ mod test {
             fix: None,
             severity: Default::default(),
         };
-        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out).unwrap();
+        let res = lint_file(&Config::default(), path, input, &[rule], &mut out).unwrap();
         assert_eq!(res.error_count, expected);
     }
 
@@ -195,7 +234,8 @@ mod test {
         };
         let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out);
         assert!(res.is_err());
-        assert!(res.unwrap_err().to_string().contains(expected_err));
+        let err = format!("{:#}", res.unwrap_err());
+        assert!(err.contains(expected_err), "unexpected error: {err}");
     }
 
     #[test]
@@ -310,5 +350,80 @@ mod test {
             "{ x = x }",
             1,
         );
+    }
+
+    #[test]
+    fn match_file_respects_path() {
+        let q = r#"((source_file) @error (#match-file? "^backend/types/"))"#;
+        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 1);
+        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 0);
+    }
+
+    #[test]
+    fn not_match_file_is_inverse() {
+        let q = r#"((source_file) @error (#not-match-file? "^backend/types/"))"#;
+        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 1);
+        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 0);
+    }
+
+    #[test]
+    fn multiple_not_match_file_predicates_are_anded() {
+        let q = r#"
+            ((source_file) @error
+             (#not-match-file? "^backend/types/")
+             (#not-match-file? "^backend/lib/"))
+        "#;
+        assert_lint_count_at_path(q, "actor { };", "src/foo.mo", 1);
+        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 0);
+        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 0);
+    }
+
+    #[test]
+    fn invalid_regex_errors() {
+        assert_lint_errors(
+            r#"((source_file) @error (#match-file? "["))"#,
+            "actor { };",
+            "invalid regex",
+        );
+    }
+
+    fn assert_rule_count(rule_path: &str, source: &str, file_path: &str, expected: usize) {
+        let mut out: Vec<u8> = vec![];
+        let rule = load_rule_from_file(Path::new(rule_path)).unwrap();
+        let res = lint_file(&Config::default(), file_path, source, &[rule], &mut out).unwrap();
+        assert_eq!(
+            res.error_count, expected,
+            "rule {rule_path} at {file_path}: expected {expected} errors"
+        );
+    }
+
+    #[test]
+    fn allowed_directories_rule() {
+        let rule = "example-rules/allowed-directories.toml";
+        let src = "actor { };";
+        for (path, expected) in [
+            ("backend/lib/foo.mo", 0),
+            ("backend/types/foo.mo", 0),
+            ("backend/mixins/foo.mo", 0),
+            ("backend/migrations/001.mo", 0),
+            ("backend/next-migration/foo.mo", 0),
+            ("backend/main.mo", 0),
+            ("src/foo.mo", 1),
+            ("backend/other/foo.mo", 1),
+            ("backend/main2.mo", 1),
+        ] {
+            assert_rule_count(rule, src, path, expected);
+        }
+    }
+
+    #[test]
+    fn types_only_scoped_by_path() {
+        let rule = "example-rules/types-only.toml";
+        let mixed_src = "module { public type T = Nat; public func f() {} };";
+        assert_rule_count(rule, mixed_src, "backend/types/foo.mo", 1);
+        assert_rule_count(rule, mixed_src, "backend/lib/foo.mo", 0);
+
+        let only_types = "module { public type T = Nat };";
+        assert_rule_count(rule, only_types, "backend/types/foo.mo", 0);
     }
 }

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -169,33 +169,37 @@ impl<'q> MatchEvaluator<'q> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Config, lint_file, test_rule};
+    use crate::{Config, Rule, lint_file};
 
     fn assert_lint_count(query: &str, input: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
-        let res = lint_file(
-            &Config::default(),
-            "<test>",
-            input,
-            &[test_rule(query)],
-            &mut out,
-        )
-        .unwrap();
+        let rule = Rule {
+            name: "test".into(),
+            description: "test".into(),
+            query: query.into(),
+            fix: None,
+            severity: Default::default(),
+            includes: vec![],
+            excludes: vec![],
+        };
+        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out).unwrap();
         assert_eq!(res.error_count, expected);
     }
 
     fn assert_lint_errors(query: &str, input: &str, expected_err: &str) {
         let mut out: Vec<u8> = vec![];
-        let res = lint_file(
-            &Config::default(),
-            "<test>",
-            input,
-            &[test_rule(query)],
-            &mut out,
-        );
+        let rule = Rule {
+            name: "test".into(),
+            description: "test".into(),
+            query: query.into(),
+            fix: None,
+            severity: Default::default(),
+            includes: vec![],
+            excludes: vec![],
+        };
+        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out);
         assert!(res.is_err());
-        let err = format!("{:#}", res.unwrap_err());
-        assert!(err.contains(expected_err), "unexpected error: {err}");
+        assert!(res.unwrap_err().to_string().contains(expected_err));
     }
 
     #[test]

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -91,20 +91,11 @@ fn eval_depth_predicate<'q>(
     Ok(depth_fn(node, types) >= threshold)
 }
 
-fn eval_file_predicate<'q>(
-    pred: &'q QueryPredicate,
-    file_path: &str,
-    regex_cache: &mut HashMap<&'q str, Regex>,
-) -> Result<bool> {
+// NOTE: regex is recompiled per match. A `CompiledRule` owning compiled queries + cached regexes across files would be the proper fix; skipped for now (perf not measured).
+fn eval_file_predicate(pred: &QueryPredicate, file_path: &str) -> Result<bool> {
     let pattern = resolve_string_arg(&pred.args, 0)?;
-    let regex = match regex_cache.entry(pattern) {
-        Entry::Occupied(e) => e.into_mut(),
-        Entry::Vacant(e) => {
-            let compiled = Regex::new(pattern)
-                .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
-            e.insert(compiled)
-        }
-    };
+    let regex = Regex::new(pattern)
+        .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
     Ok(regex.is_match(file_path))
 }
 
@@ -113,7 +104,6 @@ fn evaluate_predicates<'q>(
     captures: &[QueryCapture<'_>],
     file_path: &str,
     types_cache: &mut HashMap<&'q str, HashSet<&'q str>>,
-    regex_cache: &mut HashMap<&'q str, Regex>,
 ) -> Result<bool> {
     for pred in predicates {
         let op = pred.operator.as_ref();
@@ -127,9 +117,9 @@ fn evaluate_predicates<'q>(
                 eval_depth_predicate(pred, captures, types_cache, depth_fn)
                     .with_context(|| format!("in #{op}"))?
             }
-            "match-file?" => eval_file_predicate(pred, file_path, regex_cache)
+            "match-file?" => eval_file_predicate(pred, file_path)
                 .with_context(|| format!("in #{op}"))?,
-            "not-match-file?" => !eval_file_predicate(pred, file_path, regex_cache)
+            "not-match-file?" => !eval_file_predicate(pred, file_path)
                 .with_context(|| format!("in #{op}"))?,
             unknown => bail!("Unknown custom predicate: #{unknown}"),
         };
@@ -152,7 +142,6 @@ pub struct MatchEvaluator<'q, 'p> {
     filter_idx: Option<u32>,
     file_path: &'p str,
     types_cache: HashMap<&'q str, HashSet<&'q str>>,
-    regex_cache: HashMap<&'q str, Regex>,
 }
 
 impl<'q, 'p> MatchEvaluator<'q, 'p> {
@@ -162,7 +151,6 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
             filter_idx: query.capture_index_for_name("filter"),
             file_path,
             types_cache: HashMap::new(),
-            regex_cache: HashMap::new(),
             query,
         }
     }
@@ -175,13 +163,7 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
         }
         let predicates = self.query.general_predicates(m.pattern_index);
         if !predicates.is_empty()
-            && !evaluate_predicates(
-                predicates,
-                m.captures,
-                self.file_path,
-                &mut self.types_cache,
-                &mut self.regex_cache,
-            )?
+            && !evaluate_predicates(predicates, m.captures, self.file_path, &mut self.types_cache)?
         {
             return Ok(true);
         }

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result, bail};
-use regex::Regex;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, QueryCapture, QueryPredicate, QueryPredicateArg};
@@ -91,29 +90,10 @@ fn eval_depth_predicate<'q>(
     Ok(depth_fn(node, types) >= threshold)
 }
 
-fn eval_file_predicate<'q>(
-    pred: &'q QueryPredicate,
-    file_path: &str,
-    regex_cache: &mut HashMap<&'q str, Regex>,
-) -> Result<bool> {
-    let pattern = resolve_string_arg(&pred.args, 0)?;
-    let regex = match regex_cache.entry(pattern) {
-        Entry::Occupied(e) => e.into_mut(),
-        Entry::Vacant(e) => {
-            let compiled = Regex::new(pattern)
-                .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
-            e.insert(compiled)
-        }
-    };
-    Ok(regex.is_match(file_path))
-}
-
 fn evaluate_predicates<'q>(
     predicates: &'q [QueryPredicate],
     captures: &[QueryCapture<'_>],
-    file_path: &str,
     types_cache: &mut HashMap<&'q str, HashSet<&'q str>>,
-    regex_cache: &mut HashMap<&'q str, Regex>,
 ) -> Result<bool> {
     for pred in predicates {
         let op = pred.operator.as_ref();
@@ -127,10 +107,6 @@ fn evaluate_predicates<'q>(
                 eval_depth_predicate(pred, captures, types_cache, depth_fn)
                     .with_context(|| format!("in #{op}"))?
             }
-            "match-file?" => eval_file_predicate(pred, file_path, regex_cache)
-                .with_context(|| format!("in #{op}"))?,
-            "not-match-file?" => !eval_file_predicate(pred, file_path, regex_cache)
-                .with_context(|| format!("in #{op}"))?,
             unknown => bail!("Unknown custom predicate: #{unknown}"),
         };
         if !pass {
@@ -146,23 +122,19 @@ fn is_trailing(m: &tree_sitter::QueryMatch, idx: u32) -> bool {
         .any(|n| n.next_named_sibling().is_some())
 }
 
-pub struct MatchEvaluator<'q, 'p> {
+pub struct MatchEvaluator<'q> {
     query: &'q tree_sitter::Query,
     trailing_idx: Option<u32>,
     filter_idx: Option<u32>,
-    file_path: &'p str,
     types_cache: HashMap<&'q str, HashSet<&'q str>>,
-    regex_cache: HashMap<&'q str, Regex>,
 }
 
-impl<'q, 'p> MatchEvaluator<'q, 'p> {
-    pub fn new(query: &'q tree_sitter::Query, file_path: &'p str) -> Self {
+impl<'q> MatchEvaluator<'q> {
+    pub fn new(query: &'q tree_sitter::Query) -> Self {
         Self {
             trailing_idx: query.capture_index_for_name("trailing"),
             filter_idx: query.capture_index_for_name("filter"),
-            file_path,
             types_cache: HashMap::new(),
-            regex_cache: HashMap::new(),
             query,
         }
     }
@@ -175,13 +147,7 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
         }
         let predicates = self.query.general_predicates(m.pattern_index);
         if !predicates.is_empty()
-            && !evaluate_predicates(
-                predicates,
-                m.captures,
-                self.file_path,
-                &mut self.types_cache,
-                &mut self.regex_cache,
-            )?
+            && !evaluate_predicates(predicates, m.captures, &mut self.types_cache)?
         {
             return Ok(true);
         }
@@ -203,14 +169,9 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Config, Rule, lint_file, load_rule_from_file};
-    use std::path::Path;
+    use crate::{Config, Rule, lint_file};
 
     fn assert_lint_count(query: &str, input: &str, expected: usize) {
-        assert_lint_count_at_path(query, input, "<test>", expected);
-    }
-
-    fn assert_lint_count_at_path(query: &str, input: &str, path: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
         let rule = Rule {
             name: "test".into(),
@@ -218,8 +179,10 @@ mod test {
             query: query.into(),
             fix: None,
             severity: Default::default(),
+            includes: Vec::new(),
+            excludes: Vec::new(),
         };
-        let res = lint_file(&Config::default(), path, input, &[rule], &mut out).unwrap();
+        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out).unwrap();
         assert_eq!(res.error_count, expected);
     }
 
@@ -231,6 +194,8 @@ mod test {
             query: query.into(),
             fix: None,
             severity: Default::default(),
+            includes: Vec::new(),
+            excludes: Vec::new(),
         };
         let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out);
         assert!(res.is_err());
@@ -352,78 +317,4 @@ mod test {
         );
     }
 
-    #[test]
-    fn match_file_respects_path() {
-        let q = r#"((source_file) @error (#match-file? "^backend/types/"))"#;
-        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 1);
-        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 0);
-    }
-
-    #[test]
-    fn not_match_file_is_inverse() {
-        let q = r#"((source_file) @error (#not-match-file? "^backend/types/"))"#;
-        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 1);
-        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 0);
-    }
-
-    #[test]
-    fn multiple_not_match_file_predicates_are_anded() {
-        let q = r#"
-            ((source_file) @error
-             (#not-match-file? "^backend/types/")
-             (#not-match-file? "^backend/lib/"))
-        "#;
-        assert_lint_count_at_path(q, "actor { };", "src/foo.mo", 1);
-        assert_lint_count_at_path(q, "actor { };", "backend/types/foo.mo", 0);
-        assert_lint_count_at_path(q, "actor { };", "backend/lib/foo.mo", 0);
-    }
-
-    #[test]
-    fn invalid_regex_errors() {
-        assert_lint_errors(
-            r#"((source_file) @error (#match-file? "["))"#,
-            "actor { };",
-            "invalid regex",
-        );
-    }
-
-    fn assert_rule_count(rule_path: &str, source: &str, file_path: &str, expected: usize) {
-        let mut out: Vec<u8> = vec![];
-        let rule = load_rule_from_file(Path::new(rule_path)).unwrap();
-        let res = lint_file(&Config::default(), file_path, source, &[rule], &mut out).unwrap();
-        assert_eq!(
-            res.error_count, expected,
-            "rule {rule_path} at {file_path}: expected {expected} errors"
-        );
-    }
-
-    #[test]
-    fn allowed_directories_rule() {
-        let rule = "example-rules/allowed-directories.toml";
-        let src = "actor { };";
-        for (path, expected) in [
-            ("backend/lib/foo.mo", 0),
-            ("backend/types/foo.mo", 0),
-            ("backend/mixins/foo.mo", 0),
-            ("backend/migrations/001.mo", 0),
-            ("backend/next-migration/foo.mo", 0),
-            ("backend/main.mo", 0),
-            ("src/foo.mo", 1),
-            ("backend/other/foo.mo", 1),
-            ("backend/main2.mo", 1),
-        ] {
-            assert_rule_count(rule, src, path, expected);
-        }
-    }
-
-    #[test]
-    fn types_only_scoped_by_path() {
-        let rule = "example-rules/types-only.toml";
-        let mixed_src = "module { public type T = Nat; public func f() {} };";
-        assert_rule_count(rule, mixed_src, "backend/types/foo.mo", 1);
-        assert_rule_count(rule, mixed_src, "backend/lib/foo.mo", 0);
-
-        let only_types = "module { public type T = Nat };";
-        assert_rule_count(rule, only_types, "backend/types/foo.mo", 0);
-    }
 }

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -173,14 +173,26 @@ mod test {
 
     fn assert_lint_count(query: &str, input: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
-        let res =
-            lint_file(&Config::default(), "<test>", input, &[test_rule(query)], &mut out).unwrap();
+        let res = lint_file(
+            &Config::default(),
+            "<test>",
+            input,
+            &[test_rule(query)],
+            &mut out,
+        )
+        .unwrap();
         assert_eq!(res.error_count, expected);
     }
 
     fn assert_lint_errors(query: &str, input: &str, expected_err: &str) {
         let mut out: Vec<u8> = vec![];
-        let res = lint_file(&Config::default(), "<test>", input, &[test_rule(query)], &mut out);
+        let res = lint_file(
+            &Config::default(),
+            "<test>",
+            input,
+            &[test_rule(query)],
+            &mut out,
+        );
         assert!(res.is_err());
         let err = format!("{:#}", res.unwrap_err());
         assert!(err.contains(expected_err), "unexpected error: {err}");

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -169,35 +169,18 @@ impl<'q> MatchEvaluator<'q> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Config, Rule, lint_file};
+    use crate::{Config, lint_file, test_rule};
 
     fn assert_lint_count(query: &str, input: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
-        let rule = Rule {
-            name: "test".into(),
-            description: "test".into(),
-            query: query.into(),
-            fix: None,
-            severity: Default::default(),
-            includes: Vec::new(),
-            excludes: Vec::new(),
-        };
-        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out).unwrap();
+        let res =
+            lint_file(&Config::default(), "<test>", input, &[test_rule(query)], &mut out).unwrap();
         assert_eq!(res.error_count, expected);
     }
 
     fn assert_lint_errors(query: &str, input: &str, expected_err: &str) {
         let mut out: Vec<u8> = vec![];
-        let rule = Rule {
-            name: "test".into(),
-            description: "test".into(),
-            query: query.into(),
-            fix: None,
-            severity: Default::default(),
-            includes: Vec::new(),
-            excludes: Vec::new(),
-        };
-        let res = lint_file(&Config::default(), "<test>", input, &[rule], &mut out);
+        let res = lint_file(&Config::default(), "<test>", input, &[test_rule(query)], &mut out);
         assert!(res.is_err());
         let err = format!("{:#}", res.unwrap_err());
         assert!(err.contains(expected_err), "unexpected error: {err}");
@@ -316,5 +299,4 @@ mod test {
             1,
         );
     }
-
 }

--- a/src/custom_predicates.rs
+++ b/src/custom_predicates.rs
@@ -91,11 +91,20 @@ fn eval_depth_predicate<'q>(
     Ok(depth_fn(node, types) >= threshold)
 }
 
-// NOTE: regex is recompiled per match. A `CompiledRule` owning compiled queries + cached regexes across files would be the proper fix; skipped for now (perf not measured).
-fn eval_file_predicate(pred: &QueryPredicate, file_path: &str) -> Result<bool> {
+fn eval_file_predicate<'q>(
+    pred: &'q QueryPredicate,
+    file_path: &str,
+    regex_cache: &mut HashMap<&'q str, Regex>,
+) -> Result<bool> {
     let pattern = resolve_string_arg(&pred.args, 0)?;
-    let regex = Regex::new(pattern)
-        .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
+    let regex = match regex_cache.entry(pattern) {
+        Entry::Occupied(e) => e.into_mut(),
+        Entry::Vacant(e) => {
+            let compiled = Regex::new(pattern)
+                .with_context(|| format!("invalid regex pattern {pattern:?}"))?;
+            e.insert(compiled)
+        }
+    };
     Ok(regex.is_match(file_path))
 }
 
@@ -104,6 +113,7 @@ fn evaluate_predicates<'q>(
     captures: &[QueryCapture<'_>],
     file_path: &str,
     types_cache: &mut HashMap<&'q str, HashSet<&'q str>>,
+    regex_cache: &mut HashMap<&'q str, Regex>,
 ) -> Result<bool> {
     for pred in predicates {
         let op = pred.operator.as_ref();
@@ -117,9 +127,9 @@ fn evaluate_predicates<'q>(
                 eval_depth_predicate(pred, captures, types_cache, depth_fn)
                     .with_context(|| format!("in #{op}"))?
             }
-            "match-file?" => eval_file_predicate(pred, file_path)
+            "match-file?" => eval_file_predicate(pred, file_path, regex_cache)
                 .with_context(|| format!("in #{op}"))?,
-            "not-match-file?" => !eval_file_predicate(pred, file_path)
+            "not-match-file?" => !eval_file_predicate(pred, file_path, regex_cache)
                 .with_context(|| format!("in #{op}"))?,
             unknown => bail!("Unknown custom predicate: #{unknown}"),
         };
@@ -142,6 +152,7 @@ pub struct MatchEvaluator<'q, 'p> {
     filter_idx: Option<u32>,
     file_path: &'p str,
     types_cache: HashMap<&'q str, HashSet<&'q str>>,
+    regex_cache: HashMap<&'q str, Regex>,
 }
 
 impl<'q, 'p> MatchEvaluator<'q, 'p> {
@@ -151,6 +162,7 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
             filter_idx: query.capture_index_for_name("filter"),
             file_path,
             types_cache: HashMap::new(),
+            regex_cache: HashMap::new(),
             query,
         }
     }
@@ -163,7 +175,13 @@ impl<'q, 'p> MatchEvaluator<'q, 'p> {
         }
         let predicates = self.query.general_predicates(m.pattern_index);
         if !predicates.is_empty()
-            && !evaluate_predicates(predicates, m.captures, self.file_path, &mut self.types_cache)?
+            && !evaluate_predicates(
+                predicates,
+                m.captures,
+                self.file_path,
+                &mut self.types_cache,
+                &mut self.regex_cache,
+            )?
         {
             return Ok(true);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,47 +32,72 @@ pub struct Config {
     pub severity_override: Option<RuleSeverity>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct Rule {
+/// Raw TOML shape for a rule before glob compilation. Kept separate from [`Rule`] so the
+/// public type can carry compiled `glob::Pattern` values directly, eliminating both
+/// per-call recompilation and any "validated at load time" panics.
+#[derive(Debug, Default, Deserialize)]
+struct RawRule {
     name: String,
     description: String,
     query: String,
     fix: Option<String>,
     #[serde(default)]
     severity: RuleSeverity,
-    /// Glob patterns; when set, the rule only runs on files matching at least one pattern.
     #[serde(default)]
     includes: Vec<String>,
-    /// Glob patterns; the rule is skipped on files matching any of these.
     #[serde(default)]
     excludes: Vec<String>,
 }
 
-impl Rule {
-    /// Validates that all `includes`/`excludes` entries parse as globs.
-    /// Called at load time so typos surface before linting starts.
-    fn validate_path_filters(&self) -> Result<()> {
-        for pat in self.includes.iter().chain(self.excludes.iter()) {
-            Pattern::new(pat)
-                .with_context(|| format!("invalid glob pattern {pat:?} in rule '{}'", self.name))?;
-        }
-        Ok(())
-    }
+#[derive(Debug, Deserialize)]
+#[serde(try_from = "RawRule")]
+pub struct Rule {
+    name: String,
+    description: String,
+    query: String,
+    fix: Option<String>,
+    severity: RuleSeverity,
+    /// When non-empty, the rule only runs on files whose path matches at least one pattern.
+    /// Patterns are anchored to the full path string lintoko was handed (typically
+    /// project-relative); use `**` to match zero or more path segments.
+    includes: Vec<Pattern>,
+    /// When a path matches any pattern here, the rule is skipped. Same matching
+    /// semantics as [`Rule::includes`]. Combined with `includes`, the rule runs
+    /// when the path is included AND not excluded.
+    excludes: Vec<Pattern>,
+}
 
-    /// Path filters are matched against the path string lintoko was handed (typically project-relative).
-    /// Patterns are anchored to the full path; use `**` to match any number of segments.
-    fn applies_to(&self, path: &str) -> bool {
-        let any_match = |pats: &[String]| {
-            pats.iter()
-                .any(|p| Pattern::new(p).expect("validated at load time").matches(path))
+impl TryFrom<RawRule> for Rule {
+    type Error = anyhow::Error;
+
+    fn try_from(raw: RawRule) -> Result<Self> {
+        let compile = |pats: Vec<String>| -> Result<Vec<Pattern>> {
+            pats.into_iter()
+                .map(|p| {
+                    Pattern::new(&p).map_err(|e| {
+                        anyhow!("invalid glob pattern {p:?} in rule '{}': {e}", raw.name)
+                    })
+                })
+                .collect()
         };
-        if !self.includes.is_empty() && !any_match(&self.includes) {
-            return false;
-        }
-        if !self.excludes.is_empty() && any_match(&self.excludes) {
-            return false;
-        }
-        true
+        Ok(Rule {
+            includes: compile(raw.includes)?,
+            excludes: compile(raw.excludes)?,
+            name: raw.name,
+            description: raw.description,
+            query: raw.query,
+            fix: raw.fix,
+            severity: raw.severity,
+        })
+    }
+}
+
+impl Rule {
+    fn applies_to(&self, path: &str) -> bool {
+        // Normalize Windows paths so authors can write forward-slash globs portably.
+        let path = path.replace('\\', "/");
+        let any = |pats: &[Pattern]| pats.iter().any(|p| p.matches(&path));
+        (self.includes.is_empty() || any(&self.includes)) && !any(&self.excludes)
     }
 }
 
@@ -85,11 +110,28 @@ struct RawDiagnostic {
     severity: RuleSeverity,
 }
 
-pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
-    let content = std::fs::read_to_string(path)?;
-    let rule: Rule = toml::from_str(&content)?;
-    rule.validate_path_filters()?;
+pub fn parse_rule(content: &str) -> Result<Rule> {
+    let rule: Rule = toml::from_str(content)?;
     Ok(rule)
+}
+
+#[cfg(test)]
+pub(crate) fn test_rule(query: &str) -> Rule {
+    RawRule {
+        name: "test".into(),
+        description: "test".into(),
+        query: query.into(),
+        ..Default::default()
+    }
+    .try_into()
+    .unwrap()
+}
+
+pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read rule from '{}'", path.display()))?;
+    parse_rule(&content)
+        .with_context(|| format!("Failed to parse rule from '{}'", path.display()))
 }
 
 pub fn load_rules_from_directory(dir: &Path) -> Result<Vec<Rule>> {
@@ -396,15 +438,16 @@ mod test {
     }
 
     fn rule_with_filters(includes: &[&str], excludes: &[&str]) -> Rule {
-        Rule {
+        RawRule {
             name: "test".into(),
             description: "test".into(),
             query: "(source_file) @error".into(),
-            fix: None,
-            severity: Default::default(),
-            includes: includes.iter().map(|s| (*s).into()).collect(),
-            excludes: excludes.iter().map(|s| (*s).into()).collect(),
+            includes: includes.iter().map(|s| (*s).to_string()).collect(),
+            excludes: excludes.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
         }
+        .try_into()
+        .unwrap()
     }
 
     #[test]
@@ -429,16 +472,14 @@ mod test {
     }
 
     #[test]
-    fn invalid_glob_pattern_fails_at_load() {
+    fn invalid_glob_pattern_fails_at_parse() {
         let toml_src = r#"
 name = "bad"
 description = "bad"
 query = "(source_file) @error"
 includes = ["[unterminated"]
 "#;
-        let path = std::env::temp_dir().join("lintoko-bad-rule.toml");
-        fs::write(&path, toml_src).unwrap();
-        let err = load_rule_from_file(&path).unwrap_err();
+        let err = parse_rule(toml_src).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("invalid glob"), "unexpected error: {msg}");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ fn template(
     Ok(new)
 }
 
-fn apply_rule(rule: &Rule, tree: Node, input: &str) -> Result<Vec<RawDiagnostic>> {
+fn apply_rule(rule: &Rule, tree: Node, input: &str, path: &str) -> Result<Vec<RawDiagnostic>> {
     let query = Query::new(&tree_sitter_motoko::LANGUAGE.into(), &rule.query)
         .with_context(|| format!("Failed to create query for rule '{}'", rule.name))?;
     let error_capture_index = query.capture_index_for_name("error").with_context(|| {
@@ -111,7 +111,7 @@ fn apply_rule(rule: &Rule, tree: Node, input: &str) -> Result<Vec<RawDiagnostic>
             rule.query
         )
     })?;
-    let mut evaluator = custom_predicates::MatchEvaluator::new(&query);
+    let mut evaluator = custom_predicates::MatchEvaluator::new(&query, path);
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(&query, tree, input.as_bytes());
     let mut filtered: HashSet<Range> = HashSet::new();
@@ -225,7 +225,7 @@ pub fn lint_file(
     let tree = parser.parse(input.as_bytes(), None).unwrap();
     let mut diagnostics = Vec::new();
     for rule in rules {
-        diagnostics.extend(apply_rule(rule, tree.root_node(), input)?);
+        diagnostics.extend(apply_rule(rule, tree.root_node(), input, path)?);
     }
     if let Some(severity) = config.severity_override {
         for d in &mut diagnostics {
@@ -309,6 +309,11 @@ mod test {
         assert_eq!(str::from_utf8(&out).unwrap(), "");
     }
 
+    /// Snapshot tests use a project-relative path that satisfies all path-dependent
+    /// example rules: `backend/main.mo` is allow-listed by `allowed-directories` and
+    /// does not match `^backend/types/`, so `types-only` is silent.
+    const SNAPSHOT_PATH: &str = "backend/main.mo";
+
     #[test]
     fn it_lints_example_rules() {
         let mut out: Vec<u8> = vec![];
@@ -318,7 +323,7 @@ mod test {
         let rules = load_rules_from_directory(Path::new("example-rules")).unwrap();
         let _ = lint_file(
             &Config::default(),
-            "<input_path>",
+            SNAPSHOT_PATH,
             include_str!("../test-data.mo"),
             &rules,
             &mut out,
@@ -341,7 +346,7 @@ mod test {
                 format: OutputFormat::Text,
                 ..Config::default()
             },
-            "<input_path>",
+            SNAPSHOT_PATH,
             include_str!("../test-data.mo"),
             &rules,
             &mut out,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use glob::Pattern;
 use miette::{LabeledSpan, NamedSource, Severity, miette};
 use regex::Regex;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::{fs, io::Write, path::Path};
 use tracing::debug;
@@ -70,6 +71,9 @@ pub struct Rule {
 impl TryFrom<RawRule> for Rule {
     type Error = anyhow::Error;
 
+    // NOTE: serde flattens this Error to a de::Error via Display, which renders only
+    // the top-level message. Inline the underlying error into the format string
+    // (`": {e}"`) — `.with_context(...)` chains would be silently dropped here.
     fn try_from(raw: RawRule) -> Result<Self> {
         let compile = |pats: Vec<String>| -> Result<Vec<Pattern>> {
             pats.into_iter()
@@ -94,9 +98,7 @@ impl TryFrom<RawRule> for Rule {
 
 impl Rule {
     fn applies_to(&self, path: &str) -> bool {
-        // Normalize Windows paths so authors can write forward-slash globs portably.
-        let path = path.replace('\\', "/");
-        let any = |pats: &[Pattern]| pats.iter().any(|p| p.matches(&path));
+        let any = |pats: &[Pattern]| pats.iter().any(|p| p.matches(path));
         (self.includes.is_empty() || any(&self.includes)) && !any(&self.excludes)
     }
 }
@@ -110,7 +112,7 @@ struct RawDiagnostic {
     severity: RuleSeverity,
 }
 
-pub fn parse_rule(content: &str) -> Result<Rule> {
+pub(crate) fn parse_rule(content: &str) -> Result<Rule> {
     let rule: Rule = toml::from_str(content)?;
     Ok(rule)
 }
@@ -143,9 +145,7 @@ pub fn load_rules_from_directory(dir: &Path) -> Result<Vec<Rule>> {
         let path = entry.path();
         if path.is_file() && path.extension().unwrap_or_default() == "toml" {
             debug!("Parsing extra rule at: {}", path.display());
-            let rule = load_rule_from_file(&path)
-                .with_context(|| anyhow!("Failed to parse rule from: '{}'", path.display()))?;
-            rules.push(rule)
+            rules.push(load_rule_from_file(&path)?);
         }
     }
     Ok(rules)
@@ -301,9 +301,16 @@ pub fn lint_file(
         .set_language(&tree_sitter_motoko::LANGUAGE.into())
         .expect("Error loading Motoko grammar");
     let tree = parser.parse(input.as_bytes(), None).unwrap();
+    // Normalize Windows separators once per file so authors can write portable
+    // forward-slash globs in `includes`/`excludes`. Skips the allocation on Unix.
+    let normalized_path: Cow<str> = if path.contains('\\') {
+        Cow::Owned(path.replace('\\', "/"))
+    } else {
+        Cow::Borrowed(path)
+    };
     let mut diagnostics = Vec::new();
     for rule in rules {
-        if !rule.applies_to(path) {
+        if !rule.applies_to(&normalized_path) {
             continue;
         }
         diagnostics.extend(apply_rule(rule, tree.root_node(), input)?);
@@ -469,6 +476,21 @@ mod test {
         assert!(lib_except_internal.applies_to("backend/lib/Foo.mo"));
         assert!(!lib_except_internal.applies_to("backend/lib/internal/Foo.mo"));
         assert!(!lib_except_internal.applies_to("backend/types/Foo.mo"));
+    }
+
+    #[test]
+    fn applies_to_normalizes_windows_separators() {
+        let scoped = rule_with_filters(&["backend/types/**"], &[]);
+        let mut out: Vec<u8> = vec![];
+        let res = lint_file(
+            &Config::default(),
+            "backend\\types\\Foo.mo",
+            "actor { };",
+            &[scoped],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(res.error_count, 1, "backslash path should match forward-slash glob");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod custom_predicates;
 
 use anyhow::{Context, Result, anyhow};
+use glob::Pattern;
 use miette::{LabeledSpan, NamedSource, Severity, miette};
 use regex::Regex;
 use serde::Deserialize;
@@ -39,6 +40,40 @@ pub struct Rule {
     fix: Option<String>,
     #[serde(default)]
     severity: RuleSeverity,
+    /// Glob patterns; when set, the rule only runs on files matching at least one pattern.
+    #[serde(default)]
+    includes: Vec<String>,
+    /// Glob patterns; the rule is skipped on files matching any of these.
+    #[serde(default)]
+    excludes: Vec<String>,
+}
+
+impl Rule {
+    /// Validates that all `includes`/`excludes` entries parse as globs.
+    /// Called at load time so typos surface before linting starts.
+    fn validate_path_filters(&self) -> Result<()> {
+        for pat in self.includes.iter().chain(self.excludes.iter()) {
+            Pattern::new(pat)
+                .with_context(|| format!("invalid glob pattern {pat:?} in rule '{}'", self.name))?;
+        }
+        Ok(())
+    }
+
+    /// Path filters are matched against the path string lintoko was handed (typically project-relative).
+    /// Patterns are anchored to the full path; use `**` to match any number of segments.
+    fn applies_to(&self, path: &str) -> bool {
+        let any_match = |pats: &[String]| {
+            pats.iter()
+                .any(|p| Pattern::new(p).expect("validated at load time").matches(path))
+        };
+        if !self.includes.is_empty() && !any_match(&self.includes) {
+            return false;
+        }
+        if !self.excludes.is_empty() && any_match(&self.excludes) {
+            return false;
+        }
+        true
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +87,8 @@ struct RawDiagnostic {
 
 pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
     let content = std::fs::read_to_string(path)?;
-    let rule = toml::from_str(&content)?;
+    let rule: Rule = toml::from_str(&content)?;
+    rule.validate_path_filters()?;
     Ok(rule)
 }
 
@@ -102,7 +138,7 @@ fn template(
     Ok(new)
 }
 
-fn apply_rule(rule: &Rule, tree: Node, input: &str, path: &str) -> Result<Vec<RawDiagnostic>> {
+fn apply_rule(rule: &Rule, tree: Node, input: &str) -> Result<Vec<RawDiagnostic>> {
     let query = Query::new(&tree_sitter_motoko::LANGUAGE.into(), &rule.query)
         .with_context(|| format!("Failed to create query for rule '{}'", rule.name))?;
     let error_capture_index = query.capture_index_for_name("error").with_context(|| {
@@ -111,7 +147,7 @@ fn apply_rule(rule: &Rule, tree: Node, input: &str, path: &str) -> Result<Vec<Ra
             rule.query
         )
     })?;
-    let mut evaluator = custom_predicates::MatchEvaluator::new(&query, path);
+    let mut evaluator = custom_predicates::MatchEvaluator::new(&query);
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(&query, tree, input.as_bytes());
     let mut filtered: HashSet<Range> = HashSet::new();
@@ -225,7 +261,10 @@ pub fn lint_file(
     let tree = parser.parse(input.as_bytes(), None).unwrap();
     let mut diagnostics = Vec::new();
     for rule in rules {
-        diagnostics.extend(apply_rule(rule, tree.root_node(), input, path)?);
+        if !rule.applies_to(path) {
+            continue;
+        }
+        diagnostics.extend(apply_rule(rule, tree.root_node(), input)?);
     }
     if let Some(severity) = config.severity_override {
         for d in &mut diagnostics {
@@ -309,9 +348,9 @@ mod test {
         assert_eq!(str::from_utf8(&out).unwrap(), "");
     }
 
-    /// Snapshot tests use a project-relative path that satisfies all path-dependent
-    /// example rules: `backend/main.mo` is allow-listed by `allowed-directories` and
-    /// does not match `^backend/types/`, so `types-only` is silent.
+    /// Snapshot tests use `backend/main.mo` so that path-filtered example rules
+    /// (`allowed-directories`, `types-only`) do not fire and we exercise only
+    /// the structural rules.
     const SNAPSHOT_PATH: &str = "backend/main.mo";
 
     #[test]
@@ -354,6 +393,94 @@ mod test {
         .unwrap();
         let lint_output = str::from_utf8(&out).unwrap();
         insta::assert_snapshot!(lint_output);
+    }
+
+    fn rule_with_filters(includes: &[&str], excludes: &[&str]) -> Rule {
+        Rule {
+            name: "test".into(),
+            description: "test".into(),
+            query: "(source_file) @error".into(),
+            fix: None,
+            severity: Default::default(),
+            includes: includes.iter().map(|s| (*s).into()).collect(),
+            excludes: excludes.iter().map(|s| (*s).into()).collect(),
+        }
+    }
+
+    #[test]
+    fn applies_to_handles_includes_excludes() {
+        let no_filters = rule_with_filters(&[], &[]);
+        assert!(no_filters.applies_to("anywhere/foo.mo"));
+
+        let only_types = rule_with_filters(&["backend/types/**"], &[]);
+        assert!(only_types.applies_to("backend/types/Foo.mo"));
+        assert!(only_types.applies_to("backend/types/sub/Foo.mo"));
+        assert!(!only_types.applies_to("backend/lib/Foo.mo"));
+
+        let except_lib = rule_with_filters(&[], &["backend/lib/**"]);
+        assert!(except_lib.applies_to("backend/types/Foo.mo"));
+        assert!(!except_lib.applies_to("backend/lib/Foo.mo"));
+
+        // includes wins as a coarse filter; excludes punches a hole inside it.
+        let lib_except_internal = rule_with_filters(&["backend/lib/**"], &["**/internal/**"]);
+        assert!(lib_except_internal.applies_to("backend/lib/Foo.mo"));
+        assert!(!lib_except_internal.applies_to("backend/lib/internal/Foo.mo"));
+        assert!(!lib_except_internal.applies_to("backend/types/Foo.mo"));
+    }
+
+    #[test]
+    fn invalid_glob_pattern_fails_at_load() {
+        let toml_src = r#"
+name = "bad"
+description = "bad"
+query = "(source_file) @error"
+includes = ["[unterminated"]
+"#;
+        let path = std::env::temp_dir().join("lintoko-bad-rule.toml");
+        fs::write(&path, toml_src).unwrap();
+        let err = load_rule_from_file(&path).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("invalid glob"), "unexpected error: {msg}");
+    }
+
+    fn assert_rule_count(rule_path: &str, source: &str, file_path: &str, expected: usize) {
+        let mut out: Vec<u8> = vec![];
+        let rule = load_rule_from_file(Path::new(rule_path)).unwrap();
+        let res = lint_file(&Config::default(), file_path, source, &[rule], &mut out).unwrap();
+        assert_eq!(
+            res.error_count, expected,
+            "rule {rule_path} at {file_path}: expected {expected} errors"
+        );
+    }
+
+    #[test]
+    fn allowed_directories_rule() {
+        let rule = "example-rules/allowed-directories.toml";
+        let src = "actor { };";
+        for (path, expected) in [
+            ("backend/lib/foo.mo", 0),
+            ("backend/types/foo.mo", 0),
+            ("backend/mixins/foo.mo", 0),
+            ("backend/migrations/001.mo", 0),
+            ("backend/next-migration/foo.mo", 0),
+            ("backend/main.mo", 0),
+            ("src/foo.mo", 1),
+            ("backend/other/foo.mo", 1),
+            ("backend/main2.mo", 1),
+        ] {
+            assert_rule_count(rule, src, path, expected);
+        }
+    }
+
+    #[test]
+    fn types_only_scoped_by_path() {
+        let rule = "example-rules/types-only.toml";
+        let mixed_src = "module { public type T = Nat; public func f() {} };";
+        assert_rule_count(rule, mixed_src, "backend/types/foo.mo", 1);
+        assert_rule_count(rule, mixed_src, "backend/lib/foo.mo", 0);
+
+        let only_types = "module { public type T = Nat };";
+        assert_rule_count(rule, only_types, "backend/types/foo.mo", 0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, anyhow};
 use glob::Pattern;
 use miette::{LabeledSpan, NamedSource, Severity, miette};
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashSet;
 use std::{fs, io::Write, path::Path};
 use tracing::debug;
@@ -32,67 +32,34 @@ pub struct Config {
     pub severity_override: Option<RuleSeverity>,
 }
 
-/// Raw TOML shape for a rule before glob compilation. Kept separate from [`Rule`] so the
-/// public type can carry compiled `glob::Pattern` values directly, eliminating both
-/// per-call recompilation and any "validated at load time" panics.
-#[derive(Debug, Default, Deserialize)]
-struct RawRule {
-    name: String,
-    description: String,
-    query: String,
-    fix: Option<String>,
-    #[serde(default)]
-    severity: RuleSeverity,
-    #[serde(default)]
-    includes: Vec<String>,
-    #[serde(default)]
-    excludes: Vec<String>,
-}
-
 #[derive(Debug, Deserialize)]
-#[serde(try_from = "RawRule")]
 pub struct Rule {
     name: String,
     description: String,
     query: String,
     fix: Option<String>,
+    #[serde(default)]
     severity: RuleSeverity,
     /// When non-empty, the rule only runs on files whose path matches at least one pattern.
     /// Patterns are anchored to the full path string lintoko was handed (typically
     /// project-relative); use `**` to match zero or more path segments.
+    #[serde(default, deserialize_with = "deserialize_globs")]
     includes: Vec<Pattern>,
     /// When a path matches any pattern here, the rule is skipped. Same matching
     /// semantics as [`Rule::includes`]. Combined with `includes`, the rule runs
     /// when the path is included AND not excluded.
+    #[serde(default, deserialize_with = "deserialize_globs")]
     excludes: Vec<Pattern>,
 }
 
-impl TryFrom<RawRule> for Rule {
-    type Error = anyhow::Error;
-
-    // NOTE: serde flattens this Error to a de::Error via Display, which renders only
-    // the top-level message. Inline the underlying error into the format string
-    // (`": {e}"`) — `.with_context(...)` chains would be silently dropped here.
-    fn try_from(raw: RawRule) -> Result<Self> {
-        let compile = |pats: Vec<String>| -> Result<Vec<Pattern>> {
-            pats.into_iter()
-                .map(|p| {
-                    Pattern::new(&p).map_err(|e| {
-                        anyhow!("invalid glob pattern {p:?} in rule '{}': {e}", raw.name)
-                    })
-                })
-                .collect()
-        };
-        Ok(Rule {
-            includes: compile(raw.includes)?,
-            excludes: compile(raw.excludes)?,
-            name: raw.name,
-            description: raw.description,
-            query: raw.query,
-            fix: raw.fix,
-            severity: raw.severity,
+fn deserialize_globs<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Pattern>, D::Error> {
+    Vec::<String>::deserialize(d)?
+        .into_iter()
+        .map(|p| {
+            Pattern::new(&p)
+                .map_err(|e| serde::de::Error::custom(format!("invalid glob {p:?}: {e}")))
         })
-    }
+        .collect()
 }
 
 impl Rule {
@@ -118,14 +85,15 @@ pub(crate) fn parse_rule(content: &str) -> Result<Rule> {
 
 #[cfg(test)]
 pub(crate) fn test_rule(query: &str) -> Rule {
-    RawRule {
+    Rule {
         name: "test".into(),
         description: "test".into(),
         query: query.into(),
-        ..Default::default()
+        fix: None,
+        severity: RuleSeverity::default(),
+        includes: vec![],
+        excludes: vec![],
     }
-    .try_into()
-    .unwrap()
 }
 
 pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
@@ -436,16 +404,12 @@ mod test {
     }
 
     fn rule_with_filters(includes: &[&str], excludes: &[&str]) -> Rule {
-        RawRule {
-            name: "test".into(),
-            description: "test".into(),
-            query: "(source_file) @error".into(),
-            includes: includes.iter().map(|s| (*s).to_string()).collect(),
-            excludes: excludes.iter().map(|s| (*s).to_string()).collect(),
-            ..Default::default()
+        let compile = |pats: &[&str]| pats.iter().map(|p| Pattern::new(p).unwrap()).collect();
+        Rule {
+            includes: compile(includes),
+            excludes: compile(excludes),
+            ..test_rule("(source_file) @error")
         }
-        .try_into()
-        .unwrap()
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use glob::Pattern;
 use miette::{LabeledSpan, NamedSource, Severity, miette};
 use regex::Regex;
 use serde::Deserialize;
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::{fs, io::Write, path::Path};
 use tracing::debug;
@@ -132,8 +131,7 @@ pub(crate) fn test_rule(query: &str) -> Rule {
 pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read rule from '{}'", path.display()))?;
-    parse_rule(&content)
-        .with_context(|| format!("Failed to parse rule from '{}'", path.display()))
+    parse_rule(&content).with_context(|| format!("Failed to parse rule from '{}'", path.display()))
 }
 
 pub fn load_rules_from_directory(dir: &Path) -> Result<Vec<Rule>> {
@@ -301,16 +299,9 @@ pub fn lint_file(
         .set_language(&tree_sitter_motoko::LANGUAGE.into())
         .expect("Error loading Motoko grammar");
     let tree = parser.parse(input.as_bytes(), None).unwrap();
-    // Normalize Windows separators once per file so authors can write portable
-    // forward-slash globs in `includes`/`excludes`. Skips the allocation on Unix.
-    let normalized_path: Cow<str> = if path.contains('\\') {
-        Cow::Owned(path.replace('\\', "/"))
-    } else {
-        Cow::Borrowed(path)
-    };
     let mut diagnostics = Vec::new();
     for rule in rules {
-        if !rule.applies_to(&normalized_path) {
+        if !rule.applies_to(path) {
             continue;
         }
         diagnostics.extend(apply_rule(rule, tree.root_node(), input)?);
@@ -476,21 +467,6 @@ mod test {
         assert!(lib_except_internal.applies_to("backend/lib/Foo.mo"));
         assert!(!lib_except_internal.applies_to("backend/lib/internal/Foo.mo"));
         assert!(!lib_except_internal.applies_to("backend/types/Foo.mo"));
-    }
-
-    #[test]
-    fn applies_to_normalizes_windows_separators() {
-        let scoped = rule_with_filters(&["backend/types/**"], &[]);
-        let mut out: Vec<u8> = vec![];
-        let res = lint_file(
-            &Config::default(),
-            "backend\\types\\Foo.mo",
-            "actor { };",
-            &[scoped],
-            &mut out,
-        )
-        .unwrap();
-        assert_eq!(res.error_count, 1, "backslash path should match forward-slash glob");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,14 +40,10 @@ pub struct Rule {
     fix: Option<String>,
     #[serde(default)]
     severity: RuleSeverity,
-    /// When non-empty, the rule only runs on files whose path matches at least one pattern.
-    /// Patterns are anchored to the full path string lintoko was handed (typically
-    /// project-relative); use `**` to match zero or more path segments.
+    // Path globs the rule applies to; empty means all paths. See SKILL.md for semantics.
     #[serde(default, deserialize_with = "deserialize_globs")]
     includes: Vec<Pattern>,
-    /// When a path matches any pattern here, the rule is skipped. Same matching
-    /// semantics as [`Rule::includes`]. Combined with `includes`, the rule runs
-    /// when the path is included AND not excluded.
+    // Path globs the rule is skipped on; takes precedence over `includes`.
     #[serde(default, deserialize_with = "deserialize_globs")]
     excludes: Vec<Pattern>,
 }
@@ -64,8 +60,8 @@ fn deserialize_globs<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Pattern>, D:
 
 impl Rule {
     fn applies_to(&self, path: &str) -> bool {
-        let any = |pats: &[Pattern]| pats.iter().any(|p| p.matches(path));
-        (self.includes.is_empty() || any(&self.includes)) && !any(&self.excludes)
+        let matches_any = |pats: &[Pattern]| pats.iter().any(|p| p.matches(path));
+        (self.includes.is_empty() || matches_any(&self.includes)) && !matches_any(&self.excludes)
     }
 }
 
@@ -76,11 +72,6 @@ struct RawDiagnostic {
     range: Range,
     fix: Option<String>,
     severity: RuleSeverity,
-}
-
-pub(crate) fn parse_rule(content: &str) -> Result<Rule> {
-    let rule: Rule = toml::from_str(content)?;
-    Ok(rule)
 }
 
 #[cfg(test)]
@@ -99,7 +90,8 @@ pub(crate) fn test_rule(query: &str) -> Rule {
 pub fn load_rule_from_file(path: &Path) -> Result<Rule> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read rule from '{}'", path.display()))?;
-    parse_rule(&content).with_context(|| format!("Failed to parse rule from '{}'", path.display()))
+    toml::from_str(&content)
+        .with_context(|| format!("Failed to parse rule from '{}'", path.display()))
 }
 
 pub fn load_rules_from_directory(dir: &Path) -> Result<Vec<Rule>> {
@@ -441,24 +433,34 @@ description = "bad"
 query = "(source_file) @error"
 includes = ["[unterminated"]
 "#;
-        let err = parse_rule(toml_src).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("invalid glob"), "unexpected error: {msg}");
+        let err = toml::from_str::<Rule>(toml_src).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid glob"),
+            "unexpected error: {err}"
+        );
     }
 
-    fn assert_rule_count(rule_path: &str, source: &str, file_path: &str, expected: usize) {
+    fn assert_errors(rule: &Rule, source: &str, file_path: &str, expected: usize) {
         let mut out: Vec<u8> = vec![];
-        let rule = load_rule_from_file(Path::new(rule_path)).unwrap();
-        let res = lint_file(&Config::default(), file_path, source, &[rule], &mut out).unwrap();
+        let res = lint_file(
+            &Config::default(),
+            file_path,
+            source,
+            std::slice::from_ref(rule),
+            &mut out,
+        )
+        .unwrap();
         assert_eq!(
             res.error_count, expected,
-            "rule {rule_path} at {file_path}: expected {expected} errors"
+            "rule {} at {file_path}: expected {expected} errors",
+            rule.name
         );
     }
 
     #[test]
     fn allowed_directories_rule() {
-        let rule = "example-rules/allowed-directories.toml";
+        let rule =
+            load_rule_from_file(Path::new("example-rules/allowed-directories.toml")).unwrap();
         let src = "actor { };";
         for (path, expected) in [
             ("backend/lib/foo.mo", 0),
@@ -471,19 +473,19 @@ includes = ["[unterminated"]
             ("backend/other/foo.mo", 1),
             ("backend/main2.mo", 1),
         ] {
-            assert_rule_count(rule, src, path, expected);
+            assert_errors(&rule, src, path, expected);
         }
     }
 
     #[test]
     fn types_only_scoped_by_path() {
-        let rule = "example-rules/types-only.toml";
+        let rule = load_rule_from_file(Path::new("example-rules/types-only.toml")).unwrap();
         let mixed_src = "module { public type T = Nat; public func f() {} };";
-        assert_rule_count(rule, mixed_src, "backend/types/foo.mo", 1);
-        assert_rule_count(rule, mixed_src, "backend/lib/foo.mo", 0);
+        assert_errors(&rule, mixed_src, "backend/types/foo.mo", 1);
+        assert_errors(&rule, mixed_src, "backend/lib/foo.mo", 0);
 
         let only_types = "module { public type T = Nat };";
-        assert_rule_count(rule, only_types, "backend/types/foo.mo", 0);
+        assert_errors(&rule, only_types, "backend/types/foo.mo", 0);
     }
 
     #[test]

--- a/src/snapshots/lintoko__test__it_lints_example_rules.snap
+++ b/src/snapshots/lintoko__test__it_lints_example_rules.snap
@@ -3,7 +3,7 @@ source: src/lib.rs
 expression: lint_output
 ---
   × [ERROR]: no-result
-   ╭─[<input_path>:1:1]
+   ╭─[backend/main.mo:1:1]
  1 │ import Result "mo:base/Result";
    · ───────────────┬──────────────
    ·                ╰── Do not use the Result pattern. Use Runtime.trap() instead.
@@ -11,7 +11,7 @@ expression: lint_output
    ╰────
 
   × [ERROR]: no-pure-data-structures
-   ╭─[<input_path>:3:1]
+   ╭─[backend/main.mo:3:1]
  2 │ import OrderedMap "mo:base/OrderedMap";
  3 │ import PureList "mo:core/pure/List";
    · ─────────────────┬─────────────────
@@ -20,7 +20,7 @@ expression: lint_output
    ╰────
 
   × [ERROR]: shared-caller
-   ╭─[<input_path>:5:8]
+   ╭─[backend/main.mo:5:8]
  4 │ 
  5 │ shared (msg) actor class() {
    ·        ──┬──
@@ -29,7 +29,7 @@ expression: lint_output
    ╰────
 
   × [ERROR]: no-let-else
-   ╭─[<input_path>:7:5]
+   ╭─[backend/main.mo:7:5]
  6 │   func letElse() {
  7 │     let ?x = null else { return };
    ·     ──────────────┬──────────────
@@ -38,7 +38,7 @@ expression: lint_output
    ╰────
 
   × [ERROR]: no-flexible
-    ╭─[<input_path>:10:3]
+    ╭─[backend/main.mo:10:3]
   9 │ 
  10 │   flexible let flexibleLet = 42;
     ·   ────┬───
@@ -47,7 +47,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: no-stable
-    ╭─[<input_path>:11:3]
+    ╭─[backend/main.mo:11:3]
  10 │   flexible let flexibleLet = 42;
  11 │   stable let stableLet = 42;
     ·   ───┬──
@@ -56,7 +56,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: shared-caller
-    ╭─[<input_path>:15:16]
+    ╭─[backend/main.mo:15:16]
  14 │ 
  15 │   public shared(msg) func sharedCaller() {};
     ·                ──┬──
@@ -65,7 +65,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: shared-caller
-    ╭─[<input_path>:16:17]
+    ╭─[backend/main.mo:16:17]
  15 │   public shared(msg) func sharedCaller() {};
  16 │   public shared msg func sharedCallerVar() {};
     ·                 ─┬─
@@ -74,7 +74,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: transient-usage
-    ╭─[<input_path>:21:3]
+    ╭─[backend/main.mo:21:3]
  20 │   transient let transientMap = OrderedMap.Make<Nat>(Nat.compare);
  21 │   transient let transientMap = OrderedMap.Make.Well<Nat>(Nat.compare);
     ·   ─────────────────────────────────┬─────────────────────────────────
@@ -83,7 +83,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-plus
-    ╭─[<input_path>:23:3]
+    ╭─[backend/main.mo:23:3]
  22 │ 
  23 │   x := 1 + x;
     ·   ─────┬────
@@ -92,7 +92,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-plus
-    ╭─[<input_path>:24:3]
+    ╭─[backend/main.mo:24:3]
  23 │   x := 1 + x;
  24 │   x := x + 2;
     ·   ─────┬────
@@ -101,7 +101,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-minus
-    ╭─[<input_path>:26:3]
+    ╭─[backend/main.mo:26:3]
  25 │ 
  26 │   x := x - 1;
     ·   ─────┬────
@@ -110,7 +110,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-multiply
-    ╭─[<input_path>:29:3]
+    ╭─[backend/main.mo:29:3]
  28 │ 
  29 │   x := x * 1;
     ·   ─────┬────
@@ -119,7 +119,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-multiply
-    ╭─[<input_path>:30:3]
+    ╭─[backend/main.mo:30:3]
  29 │   x := x * 1;
  30 │   x := 1 * x;
     ·   ─────┬────
@@ -128,7 +128,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-divide
-    ╭─[<input_path>:32:3]
+    ╭─[backend/main.mo:32:3]
  31 │ 
  32 │   x := x / 1;
     ·   ─────┬────
@@ -137,7 +137,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: assign-concat
-    ╭─[<input_path>:35:3]
+    ╭─[backend/main.mo:35:3]
  34 │ 
  35 │   x := x # "1";
     ·   ──────┬─────
@@ -146,7 +146,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: pun-fields
-    ╭─[<input_path>:38:13]
+    ╭─[backend/main.mo:38:13]
  37 │ 
  38 │   let _ = { field = field };
     ·             ──────┬──────
@@ -155,7 +155,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: no-bool-switch
-    ╭─[<input_path>:40:11]
+    ╭─[backend/main.mo:40:11]
  39 │       let _ = { var dontPun = dontPun };
  40 │ ╭─▶   let _ = switch _ {
  41 │ │       case (false) {};
@@ -166,7 +166,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: no-bool-switch
-    ╭─[<input_path>:44:11]
+    ╭─[backend/main.mo:44:11]
  43 │       };
  44 │ ╭─▶   let _ = switch _ {
  45 │ │       case true {};
@@ -177,7 +177,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[<input_path>:54:47]
+    ╭─[backend/main.mo:54:47]
  53 │ 
  54 │   public func listReturningFunction() : async List<Text> {
     ·                                               ─────┬────
@@ -186,7 +186,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[<input_path>:57:46]
+    ╭─[backend/main.mo:57:46]
  56 │   };
  57 │   public func setReturningFunction() : async Set.Set<Text> {
     ·                                              ──────┬──────
@@ -195,7 +195,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[<input_path>:60:46]
+    ╭─[backend/main.mo:60:46]
  59 │   };
  60 │   public func mapReturningFunction() : async Map.Map<Text, Nat> {
     ·                                              ─────────┬────────
@@ -204,7 +204,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:73:5]
+    ╭─[backend/main.mo:73:5]
  72 │   func unneededReturn() {
  73 │     return 10
     ·     ────┬────
@@ -213,7 +213,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:75:27]
+    ╭─[backend/main.mo:75:27]
  74 │   };
  75 │   func unneededReturn() = return 10;
     ·                           ────┬────
@@ -222,7 +222,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:79:7]
+    ╭─[backend/main.mo:79:7]
  78 │     if (true) {
  79 │       return 4;
     ·       ────┬───
@@ -231,7 +231,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:86:15]
+    ╭─[backend/main.mo:86:15]
  85 │   func unneededReturn() {
  86 │     if (true) return 4
     ·               ────┬───
@@ -240,7 +240,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:95:14]
+    ╭─[backend/main.mo:95:14]
  94 │     switch (true) {
  95 │       case 1 return 40;
     ·              ────┬────
@@ -249,7 +249,7 @@ expression: lint_output
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[<input_path>:96:16]
+    ╭─[backend/main.mo:96:16]
  95 │       case 1 return 40;
  96 │       case 2 { return 40; };
     ·                ────┬────
@@ -258,7 +258,7 @@ expression: lint_output
     ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:100:8]
+     ╭─[backend/main.mo:100:8]
   99 │ 
  100 │   type lowerCase = Nat;
      ·        ────┬────
@@ -267,7 +267,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:101:8]
+     ╭─[backend/main.mo:101:8]
  100 │   type lowerCase = Nat;
  101 │   type Snake_case = Nat;
      ·        ─────┬────
@@ -276,7 +276,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:102:18]
+     ╭─[backend/main.mo:102:18]
  101 │   type Snake_case = Nat;
  102 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                  ────┬────
@@ -285,7 +285,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:102:29]
+     ╭─[backend/main.mo:102:29]
  101 │   type Snake_case = Nat;
  102 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                             ─────┬────
@@ -294,7 +294,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[<input_path>:105:8]
+     ╭─[backend/main.mo:105:8]
  104 │ 
  105 │   func UpperCase() {};
      ·        ────┬────
@@ -303,7 +303,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[<input_path>:106:8]
+     ╭─[backend/main.mo:106:8]
  105 │   func UpperCase() {};
  106 │   func snake_case() {};
      ·        ─────┬────
@@ -312,7 +312,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:108:9]
+     ╭─[backend/main.mo:108:9]
  107 │   func _hiddenIsFine() {};
  108 │   class lowerCase() {};
      ·         ────┬────
@@ -321,7 +321,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:109:9]
+     ╭─[backend/main.mo:109:9]
  108 │   class lowerCase() {};
  109 │   class Snake_Cased_ish() {};
      ·         ───────┬───────
@@ -330,7 +330,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:110:19]
+     ╭─[backend/main.mo:110:19]
  109 │   class Snake_Cased_ish() {};
  110 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                   ────┬────
@@ -339,7 +339,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: case-types
-     ╭─[<input_path>:110:30]
+     ╭─[backend/main.mo:110:30]
  109 │   class Snake_Cased_ish() {};
  110 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                              ─────┬────
@@ -348,7 +348,7 @@ expression: lint_output
      ╰────
 
   × [ERROR]: nesting-limit
-     ╭─[<input_path>:122:29]
+     ╭─[backend/main.mo:122:29]
  121 │                     if (true) {
  122 │ ╭─▶                   if (true) {
  123 │ │                       0

--- a/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
+++ b/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
@@ -2,165 +2,165 @@
 source: src/lib.rs
 expression: lint_output
 ---
-<input_path>:1:0 Error: Do not use the Result pattern. Use Runtime.trap() instead.
+backend/main.mo:1:0 Error: Do not use the Result pattern. Use Runtime.trap() instead.
 Found in:
 1 import Result "mo:base/Result";
 
-<input_path>:3:0 Error: Do not use data structures from pure/*. Use imperative structures instead.
+backend/main.mo:3:0 Error: Do not use data structures from pure/*. Use imperative structures instead.
 Found in:
 3 import PureList "mo:core/pure/List";
 
-<input_path>:5:7 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
+backend/main.mo:5:7 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
 Found in:
 5 shared (msg) actor class() {
 
-<input_path>:7:4 Error: Do not use let-else. Use a switch instead.
+backend/main.mo:7:4 Error: Do not use let-else. Use a switch instead.
 Found in:
 7     let ?x = null else { return };
 
-<input_path>:10:2 Error: Do not use the `flexible` keyword. Use `transient` instead.
+backend/main.mo:10:2 Error: Do not use the `flexible` keyword. Use `transient` instead.
 Found in:
 10   flexible let flexibleLet = 42;
 
-<input_path>:11:2 Error: Do not use the `stable` keyword. It's implicit when using persistent actors.
+backend/main.mo:11:2 Error: Do not use the `stable` keyword. It's implicit when using persistent actors.
 Found in:
 11   stable let stableLet = 42;
 
-<input_path>:15:15 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
+backend/main.mo:15:15 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
 Found in:
 15   public shared(msg) func sharedCaller() {};
 
-<input_path>:16:16 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
+backend/main.mo:16:16 Error: Do not use `shared(msg)`. Use `shared({ caller })` instead.
 Found in:
 16   public shared msg func sharedCallerVar() {};
 
-<input_path>:21:2 Error: Only use `transient` for OrderedMap.Make, OrderedSet.Make, and Random.Finite
+backend/main.mo:21:2 Error: Only use `transient` for OrderedMap.Make, OrderedSet.Make, and Random.Finite
 Found in:
 21   transient let transientMap = OrderedMap.Make.Well<Nat>(Nat.compare);
 
-<input_path>:23:2 Error: Use `x += 1` instead of reassigning the variable.
+backend/main.mo:23:2 Error: Use `x += 1` instead of reassigning the variable.
 Found in:
 23   x := 1 + x;
 
-<input_path>:24:2 Error: Use `x += 2` instead of reassigning the variable.
+backend/main.mo:24:2 Error: Use `x += 2` instead of reassigning the variable.
 Found in:
 24   x := x + 2;
 
-<input_path>:26:2 Error: Use `x -= 1` instead of reassigning the variable
+backend/main.mo:26:2 Error: Use `x -= 1` instead of reassigning the variable
 Found in:
 26   x := x - 1;
 
-<input_path>:29:2 Error: Use `x *= 1` instead of reassigning the variable.
+backend/main.mo:29:2 Error: Use `x *= 1` instead of reassigning the variable.
 Found in:
 29   x := x * 1;
 
-<input_path>:30:2 Error: Use `x *= 1` instead of reassigning the variable.
+backend/main.mo:30:2 Error: Use `x *= 1` instead of reassigning the variable.
 Found in:
 30   x := 1 * x;
 
-<input_path>:32:2 Error: Use `x /= 1` instead of reassigning the variable
+backend/main.mo:32:2 Error: Use `x /= 1` instead of reassigning the variable
 Found in:
 32   x := x / 1;
 
-<input_path>:35:2 Error: Use `x #= "1"` instead of reassigning the variable
+backend/main.mo:35:2 Error: Use `x #= "1"` instead of reassigning the variable
 Found in:
 35   x := x # "1";
 
-<input_path>:38:12 Warning: Use field punning to to avoid repetition: Replace `{ field = field }` with `{ field }`
+backend/main.mo:38:12 Warning: Use field punning to to avoid repetition: Replace `{ field = field }` with `{ field }`
 Found in:
 38   let _ = { field = field };
 
-<input_path>:40:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:40:10 Error: Don't switch on boolean values, use if instead
 Found in:
 40   let _ = switch _ {
 41     case (false) {};
 42     case (true) {};
 43   };
 
-<input_path>:44:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:44:10 Error: Don't switch on boolean values, use if instead
 Found in:
 44   let _ = switch _ {
 45     case true {};
 46     case false {};
 47   };
 
-<input_path>:54:46 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:54:46 Error: Only return primitive types from publicly exposed endpoints
 Found in:
 54   public func listReturningFunction() : async List<Text> {
 
-<input_path>:57:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:57:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
 57   public func setReturningFunction() : async Set.Set<Text> {
 
-<input_path>:60:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:60:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
 60   public func mapReturningFunction() : async Map.Map<Text, Nat> {
 
-<input_path>:73:4 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:73:4 Warning: unneeded return statement. You can remove the `return`
 Found in:
 73     return 10
 
-<input_path>:75:26 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:75:26 Warning: unneeded return statement. You can remove the `return`
 Found in:
 75   func unneededReturn() = return 10;
 
-<input_path>:79:6 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:79:6 Warning: unneeded return statement. You can remove the `return`
 Found in:
 79       return 4;
 
-<input_path>:86:14 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:86:14 Warning: unneeded return statement. You can remove the `return`
 Found in:
 86     if (true) return 4
 
-<input_path>:95:13 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:95:13 Warning: unneeded return statement. You can remove the `return`
 Found in:
 95       case 1 return 40;
 
-<input_path>:96:15 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:96:15 Warning: unneeded return statement. You can remove the `return`
 Found in:
 96       case 2 { return 40; };
 
-<input_path>:100:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:100:7 Error: Types should be capitalized and use CamelCase.
 Found in:
 100   type lowerCase = Nat;
 
-<input_path>:101:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:101:7 Error: Types should be capitalized and use CamelCase.
 Found in:
 101   type Snake_case = Nat;
 
-<input_path>:102:17 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:102:17 Error: Types should be capitalized and use CamelCase.
 Found in:
 102   type CamelCase<lowerCase, Snake_case> = Nat;
 
-<input_path>:102:28 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:102:28 Error: Types should be capitalized and use CamelCase.
 Found in:
 102   type CamelCase<lowerCase, Snake_case> = Nat;
 
-<input_path>:105:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:105:7 Error: Functions should start lower case and use camelCase.
 Found in:
 105   func UpperCase() {};
 
-<input_path>:106:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:106:7 Error: Functions should start lower case and use camelCase.
 Found in:
 106   func snake_case() {};
 
-<input_path>:108:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:108:8 Error: Types should be capitalized and use CamelCase.
 Found in:
 108   class lowerCase() {};
 
-<input_path>:109:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:109:8 Error: Types should be capitalized and use CamelCase.
 Found in:
 109   class Snake_Cased_ish() {};
 
-<input_path>:110:18 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:110:18 Error: Types should be capitalized and use CamelCase.
 Found in:
 110   class CamelCase<lowerCase, Snake_case>() {};
 
-<input_path>:110:29 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:110:29 Error: Types should be capitalized and use CamelCase.
 Found in:
 110   class CamelCase<lowerCase, Snake_case>() {};
 
-<input_path>:122:28 Error: Nesting depth exceeded maximum allowed depth of 9
+backend/main.mo:122:28 Error: Nesting depth exceeded maximum allowed depth of 9
 Found in:
 122                   if (true) {
 123                     0


### PR DESCRIPTION
## Motivation

Lintoko rules can reason about *what's* in a file but not *where* it lives. Two cases this unblocks:

1. **Enforce a directory layout** — every `.mo` file must live under one of `backend/{types,lib,mixins,migrations,next-migration}/` or be `backend/main.mo`.
2. **Scope a rule to a subdirectory** — e.g. mops' [`types-only`](https://github.com/caffeinelabs/mops/blob/main/cli/tests/lint-extra-example-rules/lint/types-only/types-only.toml) should only run under `backend/types/`.

## Design

Two optional fields on every rule TOML:

```toml
includes = ["backend/types/**"]   # only runs on matching paths
excludes = ["**/*.test.mo"]       # skipped on matching paths
```

A file passes when it matches at least one `include` (or `includes` is empty) AND no `exclude`. Patterns are `glob::Pattern`, anchored to the path string lintoko was handed (typically project-relative); `**` matches zero or more segments. Globs are compiled once at rule-load time — invalid patterns surface a clear error pointing at the rule and offending pattern.

Originally shipped as `#match-file?` / `#not-match-file?` predicates; @christoph-dfinity rightly pushed for rule-wide TOML fields. Every realistic case is expressible by either a single rule with `includes`/`excludes` or by splitting into two rules — and TOML reads better than a regex threaded into the query.

## Example rules

- `example-rules/allowed-directories.toml` — enforces the layout above.
- `example-rules/types-only.toml` — scoped port of mops' `types-only`.

## Test plan

- Unit tests for `applies_to` semantics and invalid-glob load failure.
- Integration tests for both example rules.
- Smoke test on a tmp mops project: passing and failing layouts behave correctly.
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.