### PR TITLE
feat: support func-fields (moc#6184)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 [[package]]
 name = "tree-sitter-motoko"
 version = "0.1.0"
-source = "git+https://github.com/christoph-dfinity/tree-sitter-motoko?rev=9de81ac8acee791b238727dabb6beec0c3a6eb0a#9de81ac8acee791b238727dabb6beec0c3a6eb0a"
+source = "git+https://github.com/caffeinelabs/tree-sitter-motoko?rev=refs%2Fpull%2F12%2Fhead#75440db490d22abf72793fa8e0ba2e4e58b6694b"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "lintoko"
 
 [dependencies]
 tree-sitter = "0.26"
-tree-sitter-motoko = { git = "https://github.com/christoph-dfinity/tree-sitter-motoko", rev = "9de81ac8acee791b238727dabb6beec0c3a6eb0a" }
+tree-sitter-motoko = { git = "https://github.com/caffeinelabs/tree-sitter-motoko", rev = "refs/pull/12/head" }
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/example-rules/func-field-sugar-block.toml
+++ b/example-rules/func-field-sugar-block.toml
@@ -1,0 +1,12 @@
+# Block-body variant of `func-field-sugar` (moc#6184):
+#   `name = func(...) { .. }`  →  `func name(...) { .. }`.
+# Same `!typ_params` type-param safety; `async*`/`async` ride along in return_ty.
+name = "func-field-sugar-block"
+severity = "warning"
+description = "Prefer func-field sugar: `@name = func(...) { .. }` → `func @name(...) { .. }`"
+query = """
+(exp_field
+  (identifier) @name
+  (func_exp !typ_params params: (_) @params return_ty: (typ_annot) @ret body: (block_exp) @body)) @error
+"""
+fix = "func @name@params @ret @body"

--- a/example-rules/func-field-sugar-generic.toml
+++ b/example-rules/func-field-sugar-generic.toml
@@ -1,0 +1,15 @@
+# Type-parametric variant of `func-field-sugar` (moc#6184):
+#   `name = func<T>(...) = e`  →  `func name<T>(...) = e`.
+# Captures `typ_params` (@tps) and re-emits it, so the `<T>` is preserved rather
+# than dropped — the type-param-aware counterpart to the `!typ_params`-guarded
+# plain rules. (A block-body generic field is analogous: swap `"=" (_) @rhs`
+# for `body: (block_exp) @body` and drop the `= ` from the fix.)
+name = "func-field-sugar-generic"
+severity = "warning"
+description = "Prefer func-field sugar: `@name = func<..>(...) = e` → `func @name<..>(...) = e`"
+query = """
+(exp_field
+  (identifier) @name
+  (func_exp typ_params: (typ_params) @tps params: (_) @params return_ty: (typ_annot) @ret "=" (_) @rhs)) @error
+"""
+fix = "func @name@tps@params @ret = @rhs"

--- a/example-rules/func-field-sugar.toml
+++ b/example-rules/func-field-sugar.toml
@@ -1,0 +1,16 @@
+# Example: contract a function-valued record field into the func-field sugar
+# from moc#6184 — `name = func(...) = e`  →  `func name(...) = e`.
+#
+# Plain (non-generic) expression-body form. The `!typ_params` guard makes this
+# type-param-SAFE: a generic field is left for `func-field-sugar-generic` rather
+# than silently dropping its `<T>`. `async`/`async*` ride along in `return_ty` /
+# the rhs, so they need no special handling. Block bodies are a sibling rule.
+name = "func-field-sugar"
+severity = "warning"
+description = "Prefer func-field sugar: `@name = func(...) = e` → `func @name(...) = e`"
+query = """
+(exp_field
+  (identifier) @name
+  (func_exp !typ_params params: (_) @params return_ty: (typ_annot) @ret "=" (_) @rhs)) @error
+"""
+fix = "func @name@params @ret = @rhs"

--- a/src/snapshots/lintoko__test__it_lints_example_rules.snap
+++ b/src/snapshots/lintoko__test__it_lints_example_rules.snap
@@ -154,205 +154,241 @@ expression: lint_output
  39 │   let _ = { var dontPun = dontPun };
     ╰────
 
-  × [ERROR]: no-bool-switch
-    ╭─[backend/main.mo:48:11]
- 47 │       let _ = { base with func triple(n : Nat) : Nat = n * 3 };
- 48 │ ╭─▶   let _ = switch _ {
- 49 │ │       case (false) {};
- 50 │ │       case (true) {};
- 51 │ ├─▶   };
-    · ╰──── Don't switch on boolean values, use if instead
- 52 │       let _ = switch _ {
+  ⚠ [WARNING]: func-field-sugar
+    ╭─[backend/main.mo:51:5]
+ 50 │   let _ = {
+ 51 │     encode = func(x : Nat) : Nat = x * 2;        // plain expr  → func-field-sugar
+    ·     ──────────────────┬─────────────────
+    ·                       ╰── Prefer func-field sugar: `encode = func(...) = e` → `func encode(...) = e`
+ 52 │     reduce = func(n : Nat) : Nat { n + n };      // block body  → func-field-sugar-block
+    ╰────
+
+  ⚠ [WARNING]: func-field-sugar-block
+    ╭─[backend/main.mo:52:5]
+ 51 │     encode = func(x : Nat) : Nat = x * 2;        // plain expr  → func-field-sugar
+ 52 │     reduce = func(n : Nat) : Nat { n + n };      // block body  → func-field-sugar-block
+    ·     ───────────────────┬──────────────────
+    ·                        ╰── Prefer func-field sugar: `reduce = func(...) { .. }` → `func reduce(...) { .. }`
+ 53 │     ident = func<T>(x : T) : T = x;              // generic     → func-field-sugar-generic
+    ╰────
+
+  ⚠ [WARNING]: func-field-sugar-generic
+    ╭─[backend/main.mo:53:5]
+ 52 │     reduce = func(n : Nat) : Nat { n + n };      // block body  → func-field-sugar-block
+ 53 │     ident = func<T>(x : T) : T = x;              // generic     → func-field-sugar-generic
+    ·     ───────────────┬──────────────
+    ·                    ╰── Prefer func-field sugar: `ident = func<..>(...) = e` → `func ident<..>(...) = e`
+ 54 │     fetch = func() : async* Nat = async* { 0 };  // async*      → func-field-sugar (transparent)
+    ╰────
+
+  ⚠ [WARNING]: func-field-sugar
+    ╭─[backend/main.mo:54:5]
+ 53 │     ident = func<T>(x : T) : T = x;              // generic     → func-field-sugar-generic
+ 54 │     fetch = func() : async* Nat = async* { 0 };  // async*      → func-field-sugar (transparent)
+    ·     ─────────────────────┬────────────────────
+    ·                          ╰── Prefer func-field sugar: `fetch = func(...) = e` → `func fetch(...) = e`
+ 55 │   };
     ╰────
 
   × [ERROR]: no-bool-switch
-    ╭─[backend/main.mo:52:11]
- 51 │       };
- 52 │ ╭─▶   let _ = switch _ {
- 53 │ │       case true {};
- 54 │ │       case false {};
- 55 │ ├─▶   };
+    ╭─[backend/main.mo:56:11]
+ 55 │       };
+ 56 │ ╭─▶   let _ = switch _ {
+ 57 │ │       case (false) {};
+ 58 │ │       case (true) {};
+ 59 │ ├─▶   };
     · ╰──── Don't switch on boolean values, use if instead
- 56 │     
+ 60 │       let _ = switch _ {
+    ╰────
+
+  × [ERROR]: no-bool-switch
+    ╭─[backend/main.mo:60:11]
+ 59 │       };
+ 60 │ ╭─▶   let _ = switch _ {
+ 61 │ │       case true {};
+ 62 │ │       case false {};
+ 63 │ ├─▶   };
+    · ╰──── Don't switch on boolean values, use if instead
+ 64 │     
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:62:47]
- 61 │ 
- 62 │   public func listReturningFunction() : async List<Text> {
+    ╭─[backend/main.mo:70:47]
+ 69 │ 
+ 70 │   public func listReturningFunction() : async List<Text> {
     ·                                               ─────┬────
     ·                                                    ╰── Only return primitive types from publicly exposed endpoints
- 63 │     null
+ 71 │     null
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:65:46]
- 64 │   };
- 65 │   public func setReturningFunction() : async Set.Set<Text> {
+    ╭─[backend/main.mo:73:46]
+ 72 │   };
+ 73 │   public func setReturningFunction() : async Set.Set<Text> {
     ·                                              ──────┬──────
     ·                                                    ╰── Only return primitive types from publicly exposed endpoints
- 66 │     null
+ 74 │     null
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:68:46]
- 67 │   };
- 68 │   public func mapReturningFunction() : async Map.Map<Text, Nat> {
+    ╭─[backend/main.mo:76:46]
+ 75 │   };
+ 76 │   public func mapReturningFunction() : async Map.Map<Text, Nat> {
     ·                                              ─────────┬────────
     ·                                                       ╰── Only return primitive types from publicly exposed endpoints
- 69 │     null
+ 77 │     null
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:81:5]
- 80 │   func unneededReturn() {
- 81 │     return 10
+    ╭─[backend/main.mo:89:5]
+ 88 │   func unneededReturn() {
+ 89 │     return 10
     ·     ────┬────
     ·         ╰── unneeded return statement. You can remove the `return`
- 82 │   };
+ 90 │   };
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:83:27]
- 82 │   };
- 83 │   func unneededReturn() = return 10;
+    ╭─[backend/main.mo:91:27]
+ 90 │   };
+ 91 │   func unneededReturn() = return 10;
     ·                           ────┬────
     ·                               ╰── unneeded return statement. You can remove the `return`
- 84 │ 
+ 92 │ 
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:87:7]
- 86 │     if (true) {
- 87 │       return 4;
+    ╭─[backend/main.mo:95:7]
+ 94 │     if (true) {
+ 95 │       return 4;
     ·       ────┬───
     ·           ╰── unneeded return statement. You can remove the `return`
- 88 │     } else {
+ 96 │     } else {
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:94:15]
- 93 │   func unneededReturn() {
- 94 │     if (true) return 4
-    ·               ────┬───
-    ·                   ╰── unneeded return statement. You can remove the `return`
- 95 │     else {
-    ╰────
+     ╭─[backend/main.mo:102:15]
+ 101 │   func unneededReturn() {
+ 102 │     if (true) return 4
+     ·               ────┬───
+     ·                   ╰── unneeded return statement. You can remove the `return`
+ 103 │     else {
+     ╰────
 
   ⚠ [WARNING]: unneeded-return
-     ╭─[backend/main.mo:103:14]
- 102 │     switch (true) {
- 103 │       case 1 return 40;
+     ╭─[backend/main.mo:111:14]
+ 110 │     switch (true) {
+ 111 │       case 1 return 40;
      ·              ────┬────
      ·                  ╰── unneeded return statement. You can remove the `return`
- 104 │       case 2 { return 40; };
+ 112 │       case 2 { return 40; };
      ╰────
 
   ⚠ [WARNING]: unneeded-return
-     ╭─[backend/main.mo:104:16]
- 103 │       case 1 return 40;
- 104 │       case 2 { return 40; };
+     ╭─[backend/main.mo:112:16]
+ 111 │       case 1 return 40;
+ 112 │       case 2 { return 40; };
      ·                ────┬────
      ·                    ╰── unneeded return statement. You can remove the `return`
- 105 │     };
+ 113 │     };
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:108:8]
- 107 │ 
- 108 │   type lowerCase = Nat;
+     ╭─[backend/main.mo:116:8]
+ 115 │ 
+ 116 │   type lowerCase = Nat;
      ·        ────┬────
      ·            ╰── Types should be capitalized and use CamelCase.
- 109 │   type Snake_case = Nat;
+ 117 │   type Snake_case = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:109:8]
- 108 │   type lowerCase = Nat;
- 109 │   type Snake_case = Nat;
+     ╭─[backend/main.mo:117:8]
+ 116 │   type lowerCase = Nat;
+ 117 │   type Snake_case = Nat;
      ·        ─────┬────
      ·             ╰── Types should be capitalized and use CamelCase.
- 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
+ 118 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:110:18]
- 109 │   type Snake_case = Nat;
- 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
+     ╭─[backend/main.mo:118:18]
+ 117 │   type Snake_case = Nat;
+ 118 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                  ────┬────
      ·                      ╰── Types should be capitalized and use CamelCase.
- 111 │   type CamelCase = Nat;
+ 119 │   type CamelCase = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:110:29]
- 109 │   type Snake_case = Nat;
- 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
+     ╭─[backend/main.mo:118:29]
+ 117 │   type Snake_case = Nat;
+ 118 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                             ─────┬────
      ·                                  ╰── Types should be capitalized and use CamelCase.
- 111 │   type CamelCase = Nat;
+ 119 │   type CamelCase = Nat;
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[backend/main.mo:113:8]
- 112 │ 
- 113 │   func UpperCase() {};
+     ╭─[backend/main.mo:121:8]
+ 120 │ 
+ 121 │   func UpperCase() {};
      ·        ────┬────
      ·            ╰── Functions should start lower case and use camelCase.
- 114 │   func snake_case() {};
+ 122 │   func snake_case() {};
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[backend/main.mo:114:8]
- 113 │   func UpperCase() {};
- 114 │   func snake_case() {};
+     ╭─[backend/main.mo:122:8]
+ 121 │   func UpperCase() {};
+ 122 │   func snake_case() {};
      ·        ─────┬────
      ·             ╰── Functions should start lower case and use camelCase.
- 115 │   func _hiddenIsFine() {};
+ 123 │   func _hiddenIsFine() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:116:9]
- 115 │   func _hiddenIsFine() {};
- 116 │   class lowerCase() {};
+     ╭─[backend/main.mo:124:9]
+ 123 │   func _hiddenIsFine() {};
+ 124 │   class lowerCase() {};
      ·         ────┬────
      ·             ╰── Types should be capitalized and use CamelCase.
- 117 │   class Snake_Cased_ish() {};
+ 125 │   class Snake_Cased_ish() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:117:9]
- 116 │   class lowerCase() {};
- 117 │   class Snake_Cased_ish() {};
+     ╭─[backend/main.mo:125:9]
+ 124 │   class lowerCase() {};
+ 125 │   class Snake_Cased_ish() {};
      ·         ───────┬───────
      ·                ╰── Types should be capitalized and use CamelCase.
- 118 │   class CamelCase<lowerCase, Snake_case>() {};
+ 126 │   class CamelCase<lowerCase, Snake_case>() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:118:19]
- 117 │   class Snake_Cased_ish() {};
- 118 │   class CamelCase<lowerCase, Snake_case>() {};
+     ╭─[backend/main.mo:126:19]
+ 125 │   class Snake_Cased_ish() {};
+ 126 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                   ────┬────
      ·                       ╰── Types should be capitalized and use CamelCase.
- 119 │   class CamelCase<Camel, Case>() {};
+ 127 │   class CamelCase<Camel, Case>() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:118:30]
- 117 │   class Snake_Cased_ish() {};
- 118 │   class CamelCase<lowerCase, Snake_case>() {};
+     ╭─[backend/main.mo:126:30]
+ 125 │   class Snake_Cased_ish() {};
+ 126 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                              ─────┬────
      ·                                   ╰── Types should be capitalized and use CamelCase.
- 119 │   class CamelCase<Camel, Case>() {};
+ 127 │   class CamelCase<Camel, Case>() {};
      ╰────
 
   × [ERROR]: nesting-limit
-     ╭─[backend/main.mo:130:29]
- 129 │                     if (true) {
- 130 │ ╭─▶                   if (true) {
- 131 │ │                       0
- 132 │ ├─▶                   };
+     ╭─[backend/main.mo:138:29]
+ 137 │                     if (true) {
+ 138 │ ╭─▶                   if (true) {
+ 139 │ │                       0
+ 140 │ ├─▶                   };
      · ╰──── Nesting depth exceeded maximum allowed depth of 9
- 133 │                     };
+ 141 │                     };
      ╰────

--- a/src/snapshots/lintoko__test__it_lints_example_rules.snap
+++ b/src/snapshots/lintoko__test__it_lints_example_rules.snap
@@ -155,204 +155,204 @@ expression: lint_output
     ╰────
 
   × [ERROR]: no-bool-switch
-    ╭─[backend/main.mo:40:11]
- 39 │       let _ = { var dontPun = dontPun };
- 40 │ ╭─▶   let _ = switch _ {
- 41 │ │       case (false) {};
- 42 │ │       case (true) {};
- 43 │ ├─▶   };
+    ╭─[backend/main.mo:48:11]
+ 47 │       let _ = { base with func triple(n : Nat) : Nat = n * 3 };
+ 48 │ ╭─▶   let _ = switch _ {
+ 49 │ │       case (false) {};
+ 50 │ │       case (true) {};
+ 51 │ ├─▶   };
     · ╰──── Don't switch on boolean values, use if instead
- 44 │       let _ = switch _ {
+ 52 │       let _ = switch _ {
     ╰────
 
   × [ERROR]: no-bool-switch
-    ╭─[backend/main.mo:44:11]
- 43 │       };
- 44 │ ╭─▶   let _ = switch _ {
- 45 │ │       case true {};
- 46 │ │       case false {};
- 47 │ ├─▶   };
+    ╭─[backend/main.mo:52:11]
+ 51 │       };
+ 52 │ ╭─▶   let _ = switch _ {
+ 53 │ │       case true {};
+ 54 │ │       case false {};
+ 55 │ ├─▶   };
     · ╰──── Don't switch on boolean values, use if instead
- 48 │     
+ 56 │     
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:54:47]
- 53 │ 
- 54 │   public func listReturningFunction() : async List<Text> {
+    ╭─[backend/main.mo:62:47]
+ 61 │ 
+ 62 │   public func listReturningFunction() : async List<Text> {
     ·                                               ─────┬────
     ·                                                    ╰── Only return primitive types from publicly exposed endpoints
- 55 │     null
+ 63 │     null
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:57:46]
- 56 │   };
- 57 │   public func setReturningFunction() : async Set.Set<Text> {
+    ╭─[backend/main.mo:65:46]
+ 64 │   };
+ 65 │   public func setReturningFunction() : async Set.Set<Text> {
     ·                                              ──────┬──────
     ·                                                    ╰── Only return primitive types from publicly exposed endpoints
- 58 │     null
+ 66 │     null
     ╰────
 
   × [ERROR]: only-return-primitives
-    ╭─[backend/main.mo:60:46]
- 59 │   };
- 60 │   public func mapReturningFunction() : async Map.Map<Text, Nat> {
+    ╭─[backend/main.mo:68:46]
+ 67 │   };
+ 68 │   public func mapReturningFunction() : async Map.Map<Text, Nat> {
     ·                                              ─────────┬────────
     ·                                                       ╰── Only return primitive types from publicly exposed endpoints
- 61 │     null
+ 69 │     null
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:73:5]
- 72 │   func unneededReturn() {
- 73 │     return 10
+    ╭─[backend/main.mo:81:5]
+ 80 │   func unneededReturn() {
+ 81 │     return 10
     ·     ────┬────
     ·         ╰── unneeded return statement. You can remove the `return`
- 74 │   };
+ 82 │   };
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:75:27]
- 74 │   };
- 75 │   func unneededReturn() = return 10;
+    ╭─[backend/main.mo:83:27]
+ 82 │   };
+ 83 │   func unneededReturn() = return 10;
     ·                           ────┬────
     ·                               ╰── unneeded return statement. You can remove the `return`
- 76 │ 
+ 84 │ 
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:79:7]
- 78 │     if (true) {
- 79 │       return 4;
+    ╭─[backend/main.mo:87:7]
+ 86 │     if (true) {
+ 87 │       return 4;
     ·       ────┬───
     ·           ╰── unneeded return statement. You can remove the `return`
- 80 │     } else {
+ 88 │     } else {
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:86:15]
- 85 │   func unneededReturn() {
- 86 │     if (true) return 4
+    ╭─[backend/main.mo:94:15]
+ 93 │   func unneededReturn() {
+ 94 │     if (true) return 4
     ·               ────┬───
     ·                   ╰── unneeded return statement. You can remove the `return`
- 87 │     else {
+ 95 │     else {
     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:95:14]
- 94 │     switch (true) {
- 95 │       case 1 return 40;
-    ·              ────┬────
-    ·                  ╰── unneeded return statement. You can remove the `return`
- 96 │       case 2 { return 40; };
-    ╰────
+     ╭─[backend/main.mo:103:14]
+ 102 │     switch (true) {
+ 103 │       case 1 return 40;
+     ·              ────┬────
+     ·                  ╰── unneeded return statement. You can remove the `return`
+ 104 │       case 2 { return 40; };
+     ╰────
 
   ⚠ [WARNING]: unneeded-return
-    ╭─[backend/main.mo:96:16]
- 95 │       case 1 return 40;
- 96 │       case 2 { return 40; };
-    ·                ────┬────
-    ·                    ╰── unneeded return statement. You can remove the `return`
- 97 │     };
-    ╰────
+     ╭─[backend/main.mo:104:16]
+ 103 │       case 1 return 40;
+ 104 │       case 2 { return 40; };
+     ·                ────┬────
+     ·                    ╰── unneeded return statement. You can remove the `return`
+ 105 │     };
+     ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:100:8]
-  99 │ 
- 100 │   type lowerCase = Nat;
+     ╭─[backend/main.mo:108:8]
+ 107 │ 
+ 108 │   type lowerCase = Nat;
      ·        ────┬────
      ·            ╰── Types should be capitalized and use CamelCase.
- 101 │   type Snake_case = Nat;
+ 109 │   type Snake_case = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:101:8]
- 100 │   type lowerCase = Nat;
- 101 │   type Snake_case = Nat;
+     ╭─[backend/main.mo:109:8]
+ 108 │   type lowerCase = Nat;
+ 109 │   type Snake_case = Nat;
      ·        ─────┬────
      ·             ╰── Types should be capitalized and use CamelCase.
- 102 │   type CamelCase<lowerCase, Snake_case> = Nat;
+ 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:102:18]
- 101 │   type Snake_case = Nat;
- 102 │   type CamelCase<lowerCase, Snake_case> = Nat;
+     ╭─[backend/main.mo:110:18]
+ 109 │   type Snake_case = Nat;
+ 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                  ────┬────
      ·                      ╰── Types should be capitalized and use CamelCase.
- 103 │   type CamelCase = Nat;
+ 111 │   type CamelCase = Nat;
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:102:29]
- 101 │   type Snake_case = Nat;
- 102 │   type CamelCase<lowerCase, Snake_case> = Nat;
+     ╭─[backend/main.mo:110:29]
+ 109 │   type Snake_case = Nat;
+ 110 │   type CamelCase<lowerCase, Snake_case> = Nat;
      ·                             ─────┬────
      ·                                  ╰── Types should be capitalized and use CamelCase.
- 103 │   type CamelCase = Nat;
+ 111 │   type CamelCase = Nat;
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[backend/main.mo:105:8]
- 104 │ 
- 105 │   func UpperCase() {};
+     ╭─[backend/main.mo:113:8]
+ 112 │ 
+ 113 │   func UpperCase() {};
      ·        ────┬────
      ·            ╰── Functions should start lower case and use camelCase.
- 106 │   func snake_case() {};
+ 114 │   func snake_case() {};
      ╰────
 
   × [ERROR]: case-functions
-     ╭─[backend/main.mo:106:8]
- 105 │   func UpperCase() {};
- 106 │   func snake_case() {};
+     ╭─[backend/main.mo:114:8]
+ 113 │   func UpperCase() {};
+ 114 │   func snake_case() {};
      ·        ─────┬────
      ·             ╰── Functions should start lower case and use camelCase.
- 107 │   func _hiddenIsFine() {};
+ 115 │   func _hiddenIsFine() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:108:9]
- 107 │   func _hiddenIsFine() {};
- 108 │   class lowerCase() {};
+     ╭─[backend/main.mo:116:9]
+ 115 │   func _hiddenIsFine() {};
+ 116 │   class lowerCase() {};
      ·         ────┬────
      ·             ╰── Types should be capitalized and use CamelCase.
- 109 │   class Snake_Cased_ish() {};
+ 117 │   class Snake_Cased_ish() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:109:9]
- 108 │   class lowerCase() {};
- 109 │   class Snake_Cased_ish() {};
+     ╭─[backend/main.mo:117:9]
+ 116 │   class lowerCase() {};
+ 117 │   class Snake_Cased_ish() {};
      ·         ───────┬───────
      ·                ╰── Types should be capitalized and use CamelCase.
- 110 │   class CamelCase<lowerCase, Snake_case>() {};
+ 118 │   class CamelCase<lowerCase, Snake_case>() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:110:19]
- 109 │   class Snake_Cased_ish() {};
- 110 │   class CamelCase<lowerCase, Snake_case>() {};
+     ╭─[backend/main.mo:118:19]
+ 117 │   class Snake_Cased_ish() {};
+ 118 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                   ────┬────
      ·                       ╰── Types should be capitalized and use CamelCase.
- 111 │   class CamelCase<Camel, Case>() {};
+ 119 │   class CamelCase<Camel, Case>() {};
      ╰────
 
   × [ERROR]: case-types
-     ╭─[backend/main.mo:110:30]
- 109 │   class Snake_Cased_ish() {};
- 110 │   class CamelCase<lowerCase, Snake_case>() {};
+     ╭─[backend/main.mo:118:30]
+ 117 │   class Snake_Cased_ish() {};
+ 118 │   class CamelCase<lowerCase, Snake_case>() {};
      ·                              ─────┬────
      ·                                   ╰── Types should be capitalized and use CamelCase.
- 111 │   class CamelCase<Camel, Case>() {};
+ 119 │   class CamelCase<Camel, Case>() {};
      ╰────
 
   × [ERROR]: nesting-limit
-     ╭─[backend/main.mo:122:29]
- 121 │                     if (true) {
- 122 │ ╭─▶                   if (true) {
- 123 │ │                       0
- 124 │ ├─▶                   };
+     ╭─[backend/main.mo:130:29]
+ 129 │                     if (true) {
+ 130 │ ╭─▶                   if (true) {
+ 131 │ │                       0
+ 132 │ ├─▶                   };
      · ╰──── Nesting depth exceeded maximum allowed depth of 9
- 125 │                     };
+ 133 │                     };
      ╰────

--- a/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
+++ b/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
@@ -70,98 +70,114 @@ backend/main.mo:38:12 Warning: Use field punning to to avoid repetition: Replace
 Found in:
 38   let _ = { field = field };
 
-backend/main.mo:48:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:51:4 Warning: Prefer func-field sugar: `encode = func(...) = e` → `func encode(...) = e`
 Found in:
-48   let _ = switch _ {
-49     case (false) {};
-50     case (true) {};
-51   };
+51     encode = func(x : Nat) : Nat = x * 2;        // plain expr  → func-field-sugar
 
-backend/main.mo:52:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:52:4 Warning: Prefer func-field sugar: `reduce = func(...) { .. }` → `func reduce(...) { .. }`
 Found in:
-52   let _ = switch _ {
-53     case true {};
-54     case false {};
-55   };
+52     reduce = func(n : Nat) : Nat { n + n };      // block body  → func-field-sugar-block
 
-backend/main.mo:62:46 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:53:4 Warning: Prefer func-field sugar: `ident = func<..>(...) = e` → `func ident<..>(...) = e`
 Found in:
-62   public func listReturningFunction() : async List<Text> {
+53     ident = func<T>(x : T) : T = x;              // generic     → func-field-sugar-generic
 
-backend/main.mo:65:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:54:4 Warning: Prefer func-field sugar: `fetch = func(...) = e` → `func fetch(...) = e`
 Found in:
-65   public func setReturningFunction() : async Set.Set<Text> {
+54     fetch = func() : async* Nat = async* { 0 };  // async*      → func-field-sugar (transparent)
 
-backend/main.mo:68:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:56:10 Error: Don't switch on boolean values, use if instead
 Found in:
-68   public func mapReturningFunction() : async Map.Map<Text, Nat> {
+56   let _ = switch _ {
+57     case (false) {};
+58     case (true) {};
+59   };
 
-backend/main.mo:81:4 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:60:10 Error: Don't switch on boolean values, use if instead
 Found in:
-81     return 10
+60   let _ = switch _ {
+61     case true {};
+62     case false {};
+63   };
 
-backend/main.mo:83:26 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:70:46 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-83   func unneededReturn() = return 10;
+70   public func listReturningFunction() : async List<Text> {
 
-backend/main.mo:87:6 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:73:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-87       return 4;
+73   public func setReturningFunction() : async Set.Set<Text> {
 
-backend/main.mo:94:14 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:76:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-94     if (true) return 4
+76   public func mapReturningFunction() : async Map.Map<Text, Nat> {
 
-backend/main.mo:103:13 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:89:4 Warning: unneeded return statement. You can remove the `return`
 Found in:
-103       case 1 return 40;
+89     return 10
 
-backend/main.mo:104:15 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:91:26 Warning: unneeded return statement. You can remove the `return`
 Found in:
-104       case 2 { return 40; };
+91   func unneededReturn() = return 10;
 
-backend/main.mo:108:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:95:6 Warning: unneeded return statement. You can remove the `return`
 Found in:
-108   type lowerCase = Nat;
+95       return 4;
 
-backend/main.mo:109:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:102:14 Warning: unneeded return statement. You can remove the `return`
 Found in:
-109   type Snake_case = Nat;
+102     if (true) return 4
 
-backend/main.mo:110:17 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:111:13 Warning: unneeded return statement. You can remove the `return`
 Found in:
-110   type CamelCase<lowerCase, Snake_case> = Nat;
+111       case 1 return 40;
 
-backend/main.mo:110:28 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:112:15 Warning: unneeded return statement. You can remove the `return`
 Found in:
-110   type CamelCase<lowerCase, Snake_case> = Nat;
+112       case 2 { return 40; };
 
-backend/main.mo:113:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:116:7 Error: Types should be capitalized and use CamelCase.
 Found in:
-113   func UpperCase() {};
+116   type lowerCase = Nat;
 
-backend/main.mo:114:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:117:7 Error: Types should be capitalized and use CamelCase.
 Found in:
-114   func snake_case() {};
+117   type Snake_case = Nat;
 
-backend/main.mo:116:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:118:17 Error: Types should be capitalized and use CamelCase.
 Found in:
-116   class lowerCase() {};
+118   type CamelCase<lowerCase, Snake_case> = Nat;
 
-backend/main.mo:117:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:118:28 Error: Types should be capitalized and use CamelCase.
 Found in:
-117   class Snake_Cased_ish() {};
+118   type CamelCase<lowerCase, Snake_case> = Nat;
 
-backend/main.mo:118:18 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:121:7 Error: Functions should start lower case and use camelCase.
 Found in:
-118   class CamelCase<lowerCase, Snake_case>() {};
+121   func UpperCase() {};
 
-backend/main.mo:118:29 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:122:7 Error: Functions should start lower case and use camelCase.
 Found in:
-118   class CamelCase<lowerCase, Snake_case>() {};
+122   func snake_case() {};
 
-backend/main.mo:130:28 Error: Nesting depth exceeded maximum allowed depth of 9
+backend/main.mo:124:8 Error: Types should be capitalized and use CamelCase.
 Found in:
-130                   if (true) {
-131                     0
-132                   };
+124   class lowerCase() {};
+
+backend/main.mo:125:8 Error: Types should be capitalized and use CamelCase.
+Found in:
+125   class Snake_Cased_ish() {};
+
+backend/main.mo:126:18 Error: Types should be capitalized and use CamelCase.
+Found in:
+126   class CamelCase<lowerCase, Snake_case>() {};
+
+backend/main.mo:126:29 Error: Types should be capitalized and use CamelCase.
+Found in:
+126   class CamelCase<lowerCase, Snake_case>() {};
+
+backend/main.mo:138:28 Error: Nesting depth exceeded maximum allowed depth of 9
+Found in:
+138                   if (true) {
+139                     0
+140                   };

--- a/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
+++ b/src/snapshots/lintoko__test__it_lints_with_textual_output.snap
@@ -70,98 +70,98 @@ backend/main.mo:38:12 Warning: Use field punning to to avoid repetition: Replace
 Found in:
 38   let _ = { field = field };
 
-backend/main.mo:40:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:48:10 Error: Don't switch on boolean values, use if instead
 Found in:
-40   let _ = switch _ {
-41     case (false) {};
-42     case (true) {};
-43   };
+48   let _ = switch _ {
+49     case (false) {};
+50     case (true) {};
+51   };
 
-backend/main.mo:44:10 Error: Don't switch on boolean values, use if instead
+backend/main.mo:52:10 Error: Don't switch on boolean values, use if instead
 Found in:
-44   let _ = switch _ {
-45     case true {};
-46     case false {};
-47   };
+52   let _ = switch _ {
+53     case true {};
+54     case false {};
+55   };
 
-backend/main.mo:54:46 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:62:46 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-54   public func listReturningFunction() : async List<Text> {
+62   public func listReturningFunction() : async List<Text> {
 
-backend/main.mo:57:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:65:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-57   public func setReturningFunction() : async Set.Set<Text> {
+65   public func setReturningFunction() : async Set.Set<Text> {
 
-backend/main.mo:60:45 Error: Only return primitive types from publicly exposed endpoints
+backend/main.mo:68:45 Error: Only return primitive types from publicly exposed endpoints
 Found in:
-60   public func mapReturningFunction() : async Map.Map<Text, Nat> {
+68   public func mapReturningFunction() : async Map.Map<Text, Nat> {
 
-backend/main.mo:73:4 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:81:4 Warning: unneeded return statement. You can remove the `return`
 Found in:
-73     return 10
+81     return 10
 
-backend/main.mo:75:26 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:83:26 Warning: unneeded return statement. You can remove the `return`
 Found in:
-75   func unneededReturn() = return 10;
+83   func unneededReturn() = return 10;
 
-backend/main.mo:79:6 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:87:6 Warning: unneeded return statement. You can remove the `return`
 Found in:
-79       return 4;
+87       return 4;
 
-backend/main.mo:86:14 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:94:14 Warning: unneeded return statement. You can remove the `return`
 Found in:
-86     if (true) return 4
+94     if (true) return 4
 
-backend/main.mo:95:13 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:103:13 Warning: unneeded return statement. You can remove the `return`
 Found in:
-95       case 1 return 40;
+103       case 1 return 40;
 
-backend/main.mo:96:15 Warning: unneeded return statement. You can remove the `return`
+backend/main.mo:104:15 Warning: unneeded return statement. You can remove the `return`
 Found in:
-96       case 2 { return 40; };
+104       case 2 { return 40; };
 
-backend/main.mo:100:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:108:7 Error: Types should be capitalized and use CamelCase.
 Found in:
-100   type lowerCase = Nat;
+108   type lowerCase = Nat;
 
-backend/main.mo:101:7 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:109:7 Error: Types should be capitalized and use CamelCase.
 Found in:
-101   type Snake_case = Nat;
+109   type Snake_case = Nat;
 
-backend/main.mo:102:17 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:110:17 Error: Types should be capitalized and use CamelCase.
 Found in:
-102   type CamelCase<lowerCase, Snake_case> = Nat;
+110   type CamelCase<lowerCase, Snake_case> = Nat;
 
-backend/main.mo:102:28 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:110:28 Error: Types should be capitalized and use CamelCase.
 Found in:
-102   type CamelCase<lowerCase, Snake_case> = Nat;
+110   type CamelCase<lowerCase, Snake_case> = Nat;
 
-backend/main.mo:105:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:113:7 Error: Functions should start lower case and use camelCase.
 Found in:
-105   func UpperCase() {};
+113   func UpperCase() {};
 
-backend/main.mo:106:7 Error: Functions should start lower case and use camelCase.
+backend/main.mo:114:7 Error: Functions should start lower case and use camelCase.
 Found in:
-106   func snake_case() {};
+114   func snake_case() {};
 
-backend/main.mo:108:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:116:8 Error: Types should be capitalized and use CamelCase.
 Found in:
-108   class lowerCase() {};
+116   class lowerCase() {};
 
-backend/main.mo:109:8 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:117:8 Error: Types should be capitalized and use CamelCase.
 Found in:
-109   class Snake_Cased_ish() {};
+117   class Snake_Cased_ish() {};
 
-backend/main.mo:110:18 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:118:18 Error: Types should be capitalized and use CamelCase.
 Found in:
-110   class CamelCase<lowerCase, Snake_case>() {};
+118   class CamelCase<lowerCase, Snake_case>() {};
 
-backend/main.mo:110:29 Error: Types should be capitalized and use CamelCase.
+backend/main.mo:118:29 Error: Types should be capitalized and use CamelCase.
 Found in:
-110   class CamelCase<lowerCase, Snake_case>() {};
+118   class CamelCase<lowerCase, Snake_case>() {};
 
-backend/main.mo:122:28 Error: Nesting depth exceeded maximum allowed depth of 9
+backend/main.mo:130:28 Error: Nesting depth exceeded maximum allowed depth of 9
 Found in:
-122                   if (true) {
-123                     0
-124                   };
+130                   if (true) {
+131                     0
+132                   };

--- a/test-data.mo
+++ b/test-data.mo
@@ -45,6 +45,14 @@ shared (msg) actor class() {
     plain = 5;
   };
   let _ = { base with func triple(n : Nat) : Nat = n * 3 };
+
+  // verbose lambda-fields — the func-field-sugar rules suggest contractions
+  let _ = {
+    encode = func(x : Nat) : Nat = x * 2;        // plain expr  → func-field-sugar
+    reduce = func(n : Nat) : Nat { n + n };      // block body  → func-field-sugar-block
+    ident = func<T>(x : T) : T = x;              // generic     → func-field-sugar-generic
+    fetch = func() : async* Nat = async* { 0 };  // async*      → func-field-sugar (transparent)
+  };
   let _ = switch _ {
     case (false) {};
     case (true) {};

--- a/test-data.mo
+++ b/test-data.mo
@@ -37,6 +37,14 @@ shared (msg) actor class() {
 
   let _ = { field = field };
   let _ = { var dontPun = dontPun };
+
+  // func-fields (moc #6184) — must parse cleanly (no ERROR nodes)
+  let _ = {
+    func incr(x : Nat) : Nat = x + 1;
+    func double(n : Nat) : Nat { n + n };
+    plain = 5;
+  };
+  let _ = { base with func triple(n : Nat) : Nat = n * 3 };
   let _ = switch _ {
     case (false) {};
     case (true) {};


### PR DESCRIPTION
Companion to caffeinelabs/motoko#6184 — func-field syntax (`func name(args) : T <body>`).

Depends on caffeinelabs/tree-sitter-motoko#12; `Cargo.toml` pins its PR ref — re-pin to the merged rev before merging. 23/23 green, no behavior change.